### PR TITLE
chore: Testing Update + Telemetry Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,3 @@ bash release/docker/deploy.sh --build --wheel
 ## License
 
 This project is licensed under the [Apache-2.0](LICENSE) License.
-

--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ bash release/docker/deploy.sh --build --wheel
 ## License
 
 This project is licensed under the [Apache-2.0](LICENSE) License.
+

--- a/nvidia_tao_deploy/cv/common/entrypoint/entrypoint_hydra.py
+++ b/nvidia_tao_deploy/cv/common/entrypoint/entrypoint_hydra.py
@@ -27,7 +27,12 @@ try:
 except ImportError:
     DEFAULT_SPECS_AVAILABLE = False
     default_specs = None
-from nvidia_tao_core.telemetry.telemetry import send_telemetry_data
+try:
+    from nvidia_tao_core.telemetry.telemetry import send_telemetry_data
+    TELEMETRY_AVAILABLE = True
+except ImportError:
+    send_telemetry_data = None
+    TELEMETRY_AVAILABLE = False
 
 
 RELEASE = True
@@ -319,26 +324,29 @@ def launch(args, unknown_args, subtasks, network="tao-deploy"):
     end = time()
     time_lapsed = int(end - start)
 
-    try:
-        gpu_data = []
-        for device in get_device_details():
-            gpu_data.append(device.get_config())
-        logger.info("Sending telemetry data.")
-        send_telemetry_data(
-            network,
-            args["subtask"],
-            gpu_data,
-            num_gpus=num_gpus,
-            time_lapsed=time_lapsed,
-            pass_status=process_passed,
-            user_error=user_error
-        )
-    except Exception as e:
-        logger.warning(
-            "Telemetry data couldn't be sent, but the command ran successfully."
-        )
-        logger.warning("{}".format(e))
-        pass
+    if not TELEMETRY_AVAILABLE:
+        logger.info("Telemetry module not available; skipping telemetry reporting.")
+    else:
+        try:
+            gpu_data = []
+            for device in get_device_details():
+                gpu_data.append(device.get_config())
+            logger.info("Sending telemetry data.")
+            send_telemetry_data(
+                network,
+                args["subtask"],
+                gpu_data,
+                num_gpus=num_gpus,
+                time_lapsed=time_lapsed,
+                pass_status=process_passed,
+                user_error=user_error
+            )
+        except Exception as e:
+            logger.warning(
+                "Telemetry data couldn't be sent, but the command ran successfully."
+            )
+            logger.warning("{}".format(e))
+            pass
 
     if not process_passed:
         status_logging.get_status_logger().write(

--- a/nvidia_tao_deploy/cv/common/entrypoint/entrypoint_proto.py
+++ b/nvidia_tao_deploy/cv/common/entrypoint/entrypoint_proto.py
@@ -15,7 +15,12 @@ from time import time
 import pycuda.driver as cuda
 
 from nvidia_tao_deploy.cv.common.telemetry.nvml_utils import get_device_details
-from nvidia_tao_core.telemetry.telemetry import send_telemetry_data
+try:
+    from nvidia_tao_core.telemetry.telemetry import send_telemetry_data
+    TELEMETRY_AVAILABLE = True
+except ImportError:
+    send_telemetry_data = None
+    TELEMETRY_AVAILABLE = False
 
 RELEASE = True
 # Configure the logger.
@@ -250,23 +255,26 @@ def launch_job(package, package_name, cl_args=None):
     end = time()
     time_lapsed = end - start
 
-    try:
-        gpu_data = []
-        for device in get_device_details():
-            gpu_data.append(device.get_config())
-        logger.info("Sending telemetry data.")
-        send_telemetry_data(
-            package_name,
-            task,
-            gpu_data,
-            num_gpus=1,
-            time_lapsed=time_lapsed,
-            pass_status=process_passed
-        )
-    except Exception as e:
-        logger.warning("Telemetry data couldn't be sent, but the command ran successfully.")
-        logger.warning("[Error]: {}".format(e))  # noqa pylint: disable=C0209
-        pass
+    if not TELEMETRY_AVAILABLE:
+        logger.info("Telemetry module not available; skipping telemetry reporting.")
+    else:
+        try:
+            gpu_data = []
+            for device in get_device_details():
+                gpu_data.append(device.get_config())
+            logger.info("Sending telemetry data.")
+            send_telemetry_data(
+                package_name,
+                task,
+                gpu_data,
+                num_gpus=1,
+                time_lapsed=time_lapsed,
+                pass_status=process_passed
+            )
+        except Exception as e:
+            logger.warning("Telemetry data couldn't be sent, but the command ran successfully.")
+            logger.warning("[Error]: {}".format(e))  # noqa pylint: disable=C0209
+            pass
 
     if not process_passed:
         logger.info("Execution status: FAIL")

--- a/release/docker/Dockerfile.release
+++ b/release/docker/Dockerfile.release
@@ -26,7 +26,9 @@ COPY release/docker/entrypoint.d/* /opt/nvidia/entrypoint.d/
 
 # Installing TAO-Core
 COPY tao-core tao-core
-RUN cd tao-core && bash release/python/build_wheel.sh && \
+RUN cd tao-core && \
+    pip install --upgrade pip setuptools wheel && \
+    python setup.py bdist_wheel && \
     find dist/ -name "nvidia_tao_core*.whl" -type f | xargs -n 1 pip install && \
     cp nvidia_tao_core/microservices/nginx.conf /etc/nginx/ && \
     cd .. && rm -rf tao-core

--- a/tests/centerpose/__init__.py
+++ b/tests/centerpose/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CenterPose Unit Tests."""

--- a/tests/centerpose/test_dataloader.py
+++ b/tests/centerpose/test_dataloader.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CenterPose Data Loading Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+import json
+from PIL import Image
+import tempfile
+from omegaconf import OmegaConf
+
+from nvidia_tao_deploy.config.centerpose.dataset import CenterPoseDatasetConfig
+from nvidia_tao_deploy.cv.centerpose.dataloader import CPPredictDataset
+
+TARGET_WIDTH = 512
+TARGET_HEIGHT = 512
+JSON_DICT = {
+    "AR_data": {
+        "plane_center": [
+            0.09141058474779129,
+            -0.4654481112957001,
+            -2.084526300430298
+        ],
+        "plane_normal": [
+            -0.6214213967323303,
+            0.614223301410675,
+            0.48637959361076355
+        ]
+    },
+    "camera_data": {
+        "camera_projection_matrix": [
+            [
+                1.52635657787323,
+                0.0,
+                0.009838283061981201,
+                0.0
+            ],
+            [
+                0.0,
+                2.035142183303833,
+                -0.01886594295501709,
+                0.0
+            ],
+            [
+                0.0,
+                0.0,
+                -0.9999997615814209,
+                -0.0009999998146668077
+            ],
+            [
+                0.0,
+                0.0,
+                -1.0,
+                0.0
+            ]
+        ],
+        "camera_view_matrix": [
+            [
+                -0.7896934747695923,
+                -0.611926257610321,
+                -0.04394054785370827,
+                5.343637943267822
+            ],
+            [
+                -0.5105103850364685,
+                0.6157151460647583,
+                0.6002286672592163,
+                10.670602798461914
+            ],
+            [
+                -0.3402407467365265,
+                0.49642857909202576,
+                -0.7986208200454712,
+                -8.142728805541992
+            ],
+            [
+                0.0,
+                0.0,
+                0.0,
+                1.0000005960464478
+            ]
+        ],
+        "height": 800,
+        "intrinsics": {
+            "cx": 294.1318766276042,
+            "cy": 395.8563486735026,
+            "fx": 610.5426534016927,
+            "fy": 610.5426534016927
+        },
+        "width": 600
+    },
+    "objects": [
+        {
+            "class": "bike",
+            "keypoints_3d": [
+                [
+                    -0.24901613593101501,
+                    -0.12291328608989716,
+                    -1.8083537817001343
+                ],
+                [
+                    0.8577174544334412,
+                    0.013282767497003078,
+                    -1.7100194692611694
+                ],
+                [
+                    -0.3679855167865753,
+                    -0.33202818036079407,
+                    -2.8399617671966553
+                ],
+                [
+                    0.17686404287815094,
+                    0.6983523964881897,
+                    -1.1576735973358154
+                ],
+                [
+                    -1.0488389730453491,
+                    0.353040486574173,
+                    -2.2876148223876953
+                ],
+                [
+                    0.5508071184158325,
+                    -0.5988670587539673,
+                    -1.3290935754776
+                ],
+                [
+                    -0.6748962998390198,
+                    -0.9441789984703064,
+                    -2.459033966064453
+                ],
+                [
+                    -0.1300462931394577,
+                    0.08620256930589676,
+                    -0.7767467498779297
+                ],
+                [
+                    -1.3557497262954712,
+                    -0.25910934805870056,
+                    -1.9066879749298096
+                ]
+            ],
+            "location": [
+                -0.2490161657333374,
+                -0.12291321158409119,
+                -1.8083552122116089
+            ],
+            "name": "bike_0",
+            "projected_cuboid": [
+                [
+                    264.1417980194092,
+                    311.9422912597656
+                ],
+                [
+                    310.40804386138916,
+                    702.4796009063721
+                ],
+                [
+                    234.25626754760742,
+                    316.9247627258301
+                ],
+                [
+                    674.2854595184326,
+                    489.41755294799805
+                ],
+                [
+                    399.9269485473633,
+                    116.0151720046997
+                ],
+                [
+                    30.356186628341675,
+                    649.2752075195312
+                ],
+                [
+                    71.1406409740448,
+                    228.42774391174316
+                ],
+                [
+                    373.51176738739014,
+                    293.7072515487671
+                ],
+                [
+                    222.6496696472168,
+                    -38.29150199890137
+                ]
+            ],
+            "provenance": "objectron",
+            "quaternion_xyzw": [
+                -0.42756551547095173,
+                0.8197863197504603,
+                0.09010790219499404,
+                -0.37016035159383637
+            ],
+            "scale": [
+                0.783598780632019,
+                1.1126405000686646,
+                1.702457070350647
+            ],
+            "visibility": 1.0
+        }
+    ]
+}
+
+@pytest.mark.parametrize("data_format", ["channels_first"])
+@pytest.mark.parametrize("num_channels", [3])
+def test_dataloader(data_format, num_channels):
+    if data_format == "channels_first":
+        input_shape = (1, num_channels, TARGET_HEIGHT, TARGET_WIDTH)
+    else:
+        input_shape = (1, TARGET_HEIGHT, TARGET_WIDTH, num_channels)
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+
+        # Load dummy image
+        img_width = JSON_DICT['camera_data']['width']
+        img_height = JSON_DICT['camera_data']['height']
+
+        dummy_image = np.random.randint(low=0, high=255, size=(img_height, img_width, 3), dtype=np.uint8)
+        dummy_image = Image.fromarray(dummy_image)
+
+        # Save dummy image
+        dummy_image.save(os.path.join(tmpdirname, "temp.png"))
+
+        # Dataset config
+        data_config = OmegaConf.structured(CenterPoseDatasetConfig())
+
+        # Store json file
+        with open(os.path.join(tmpdirname, "temp.json"), "w") as f:
+            json.dump(JSON_DICT, f)
+
+        dl = CPPredictDataset(
+            dataset_config=data_config,
+            inference_data=tmpdirname,
+            shape=input_shape,
+            dtype=np.float32,
+            evaluate=True)
+
+        for batches, img_paths, batch_params in dl.get_evaluation_batch():
+            batch_c, batch_s, _, batch_intrinsic = batch_params
+
+            assert batches[0].shape == input_shape[1:], "Incorrect image dimension"
+            assert batch_c.shape[1] == 2, "Incorrect principle points format"
+            assert batch_s.shape[1] == 1, "Incorrect maximum format"
+            assert batch_intrinsic.shape[1:] == (3, 3), "Incorrect intrinsic matrix format"

--- a/tests/centerpose/test_engine.py
+++ b/tests/centerpose/test_engine.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CenterPose Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+
+from nvidia_tao_deploy.utils.decoding import decode_model
+from nvidia_tao_deploy.cv.centerpose.engine_builder import CenterPoseEngineBuilder
+from nvidia_tao_deploy.cv.centerpose.inferencer import CenterPoseInferencer
+
+
+onnx_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+TARGET_WIDTH = 512
+TARGET_HEIGHT = 512
+
+
+@pytest.mark.parametrize("onnx_path", [os.path.join(onnx_path, "centerpose/bike_DLA34.onnx")])
+@pytest.mark.parametrize("num_channels", [3])
+# @pytest.mark.parametrize("data_type", ["fp32", "fp16"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+def test_fp_engine(onnx_path, data_type, num_channels, batch_size):
+    # Check the onnx model exists.
+    if not os.path.exists(onnx_path):
+        raise ValueError(f"The ONNX model path {onnx_path} is incorrect.")
+    tmp_onnx_file, file_format = decode_model(onnx_path)
+
+    # # Engine building part
+    output_engine_path = f"/tmp/centerpose_{data_type}.engine"
+
+    builder = CenterPoseEngineBuilder(workspace=1,
+                                      min_batch_size=1,
+                                      opt_batch_size=2,
+                                      max_batch_size=4,
+                                      )
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(output_engine_path, data_type)
+
+    if not os.path.exists(output_engine_path):
+        raise FileNotFoundError(f"Provided evaluate.trt_engine at {output_engine_path} does not exist!")
+
+    trt_infer = CenterPoseInferencer(output_engine_path, batch_size=batch_size, data_format="channel_first")
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == num_channels, "Incorrect channel size"
+
+    # Create dummy images
+    dummy_images = []
+    for _ in range(batch_size):
+        dummy_image = np.random.randint(low=0, high=255, size=(TARGET_HEIGHT, TARGET_WIDTH, 3), dtype=np.uint8)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+
+    det = trt_infer.infer(dummy_images)
+
+    pred_keys = ['bboxes', 'scores', 'kps', 'clses', 'obj_scale', 'kps_displacement_mean', 'kps_heatmap_mean']
+    assert sorted(det.keys()) == sorted(pred_keys), "Prediction does not have correct format"
+    assert det['bboxes'].shape[-1] == 4, "Incorrect bounding boxes format"
+    assert det['scores'].shape[-1] == 1, "Incorrect score format"
+    assert det['kps'].shape[-1] == 16, "Incorrect keypoints format"
+    assert det['clses'].shape[-1] == 1, "Incorrect class format"
+    assert det['obj_scale'].shape[-1] == 3, "Incorrect object scale format"
+    assert det['kps_displacement_mean'].shape[-1] == 16, "Incorrect displacement heatmap format"
+    assert det['kps_heatmap_mean'].shape[-1] == 16, "Incorrect heatmap format"
+
+    assert len({v.shape[0] for v in det.values()}) == 1, "Incorrect batch size processing"
+
+# TODO: Need to add a functional test for evaluation with accuracy check.

--- a/tests/classification_tf1/__init__.py
+++ b/tests/classification_tf1/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Classification TF1 Unit Tests."""

--- a/tests/classification_tf1/test_dataloader.py
+++ b/tests/classification_tf1/test_dataloader.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Classification Data Loading Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+import tempfile
+
+from nvidia_tao_deploy.cv.classification_tf1.dataloader import ClassificationLoader
+
+
+TARGET_WIDTH = 224
+TARGET_HEIGHT = 224
+
+
+@pytest.mark.classification_tf1
+@pytest.mark.parametrize("data_format", ["channels_first", "channels_last"])
+# @pytest.mark.parametrize("num_channels", [1, 3])
+@pytest.mark.parametrize("num_channels", [3]) # TODO: Add grayscale support
+@pytest.mark.parametrize("interpolation_method", ["bilinear", "bicubic"])
+@pytest.mark.parametrize("mode", ["caffe", "torch"])
+@pytest.mark.parametrize("crop", ["center", "random"])
+def test_dataloader(data_format, num_channels, interpolation_method, mode, crop):
+    # 4 classes dataset scenario
+    dummy_classes = {"a": 0, "b": 1, "c": 2, "d": 3}
+
+    if data_format == "channels_first":
+        input_shape = (num_channels, TARGET_HEIGHT, TARGET_WIDTH)
+    else:
+        input_shape = (TARGET_HEIGHT, TARGET_WIDTH, num_channels)
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+
+        for cls in dummy_classes.keys():
+            # Create class directory
+            os.makedirs(os.path.join(tmpdirname, cls), exist_ok=True)
+
+            # Load dummy image
+            img_width = np.random.randint(low=200, high=300)
+            img_height = np.random.randint(low=200, high=300)
+
+            dummy_image = np.random.randint(low=0, high=255, size=(img_height, img_width, 3), dtype=np.uint8)
+            dummy_image = Image.fromarray(dummy_image)
+
+            # Save dummy image
+            dummy_image.save(os.path.join(tmpdirname, cls, "0000.jpg"))
+    
+        dl = ClassificationLoader(
+            input_shape,
+            [tmpdirname],
+            dummy_classes,
+            data_format=data_format,
+            interpolation_method=interpolation_method,
+            mode=mode,
+            crop=crop,
+            batch_size=1,
+            image_mean=None,
+            dtype=np.float32)
+
+        for (imgs, labels), cls in zip(dl, dummy_classes.values()):
+            assert labels[0] == cls, "Label does not match"
+
+            if data_format == "channels_first":
+                b, c, h, w = imgs.shape
+            else:
+                b, h, w, c = imgs.shape
+            
+            assert b == 1, "Batch size does not match"
+            assert c == num_channels, "Height does not match"
+            assert h == TARGET_HEIGHT, "Height does not match"
+            assert w == TARGET_WIDTH, "Height does not match"

--- a/tests/classification_tf1/test_engine.py
+++ b/tests/classification_tf1/test_engine.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Classification Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from nvidia_tao_deploy.utils.decoding import decode_etlt
+from nvidia_tao_deploy.cv.classification_tf1.engine_builder import ClassificationEngineBuilder
+from nvidia_tao_deploy.cv.classification_tf1.inferencer import ClassificationInferencer
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+TARGET_WIDTH = 224
+TARGET_HEIGHT = 224
+OUTPUT_SHAPE = (1000,)
+
+
+@pytest.mark.classification_tf1
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "classification_tf2/efficientnet-b0-qat_050.etlt")])
+@pytest.mark.parametrize("model_key", ["nvidia_tlt"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("data_format", ["channel_last"])
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+def test_fp_engine(model_path, model_key, data_type, data_format, batch_size):
+    # Engine building part
+    if model_path.endswith("etlt"):
+        tmp_onnx_file, file_format = decode_etlt(model_path, model_key)
+    else:
+        raise ValueError(f"{model_path} has incorrect extension")
+
+    output_engine_path = f"/tmp/classification_tf1.{data_type}.engine"
+
+    builder = ClassificationEngineBuilder(min_batch_size=1,
+                                          opt_batch_size=2,
+                                          max_batch_size=4)
+    builder.create_network(tmp_onnx_file, file_format=file_format)
+    builder.create_engine(output_engine_path, data_type, tf2=True)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = ClassificationInferencer(output_engine_path, data_format=data_format, batch_size=batch_size)
+
+    # Check engine model shape
+    if data_format == "channel_first":
+        c, h, w = trt_infer.input_tensors[0].shape
+    else:
+        h, w, c = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == 3, "Incorrect channel size"
+
+    dummy_images = []
+
+    for _ in range(batch_size):
+        # Load dummy image
+        dummy_image = np.random.randint(low=0, high=255, size=(TARGET_HEIGHT, TARGET_WIDTH, 3), dtype=np.uint8)
+        dummy_image = np.asarray(dummy_image, np.float32)
+        if data_format == "channel_first":
+            dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+
+    y_pred = trt_infer.infer(dummy_images)
+
+    assert y_pred.shape == (batch_size,) + OUTPUT_SHAPE, "Incorrect output dimensions"

--- a/tests/classification_tf1/test_proto.py
+++ b/tests/classification_tf1/test_proto.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests to load configurations from proto."""
+
+import pytest
+# from nvidia_tao_deploy.cv.classification_tf1.proto.utils import load_proto
+
+
+@pytest.mark.skip
+@pytest.mark.core
+@pytest.mark.parametrize("proto_path", ["nvidia_tao_deploy/cv/classification_tf1/specs/experiment_spec.txt"])
+def test_protob_based_spec_load(proto_path):
+    es = load_proto(proto_path)
+
+    assert es.train_config.preprocess_mode == "caffe"
+    assert es.eval_config.enable_center_crop == True
+    assert es.model_config.resize_interpolation_method == 0

--- a/tests/clip/test_dataloader.py
+++ b/tests/clip/test_dataloader.py
@@ -1,0 +1,357 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLIP Dataloader Unit Tests."""
+
+import os
+import tempfile
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from nvidia_tao_deploy.multimodal.clip.dataloader import CLIPRetrievalLoader
+
+
+def _create_retrieval_dataset(tmpdir, samples):
+    """Create retrieval dataset with images and caption files.
+
+    Args:
+        tmpdir: Root directory.
+        samples: List of (image_name, caption_text) tuples.
+
+    Returns:
+        (image_dir, caption_dir) tuple.
+    """
+    image_dir = os.path.join(tmpdir, "images")
+    caption_dir = os.path.join(tmpdir, "captions")
+    os.makedirs(image_dir, exist_ok=True)
+    os.makedirs(caption_dir, exist_ok=True)
+
+    for img_name, caption in samples:
+        img_path = os.path.join(image_dir, img_name)
+        img = Image.fromarray(
+            np.random.randint(0, 255, (64, 64, 3), dtype=np.uint8)
+        )
+        img.save(img_path)
+
+        stem = os.path.splitext(img_name)[0]
+        caption_path = os.path.join(caption_dir, f"{stem}.txt")
+        with open(caption_path, "w", encoding="utf-8") as f:
+            f.write(caption)
+
+    return image_dir, caption_dir
+
+
+class TestCLIPRetrievalLoaderInit:
+    """Tests for CLIPRetrievalLoader initialization."""
+
+    def test_basic_init(self):
+        """Test basic initialization with images and captions."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            samples = [
+                ("img_0001.jpg", "a photo of a cat"),
+                ("img_0002.jpg", "a photo of a dog"),
+                ("img_0003.jpg", "a photo of a bird"),
+                ("img_0004.jpg", "a photo of a fish"),
+            ]
+            image_dir, caption_dir = _create_retrieval_dataset(tmpdir, samples)
+
+            dl = CLIPRetrievalLoader(
+                shape=(3, 224, 224),
+                image_dir=image_dir,
+                caption_dir=caption_dir,
+                batch_size=2,
+                dtype=np.float32,
+                model_type="clip",
+            )
+            assert dl.height == 224
+            assert dl.width == 224
+            assert dl.num_channels == 3
+            assert dl.n_samples == 4
+            assert dl.n_batches == 2
+            assert dl.batch_size == 2
+
+    def test_caption_in_same_dir(self):
+        """Test when captions are in the same directory as images."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            image_dir = tmpdir
+
+            for i in range(4):
+                img = Image.fromarray(
+                    np.random.randint(0, 255, (64, 64, 3), dtype=np.uint8)
+                )
+                img.save(os.path.join(image_dir, f"img_{i:04d}.jpg"))
+                with open(
+                    os.path.join(image_dir, f"img_{i:04d}.txt"), "w",
+                    encoding="utf-8"
+                ) as f:
+                    f.write(f"caption {i}")
+
+            dl = CLIPRetrievalLoader(
+                shape=(3, 224, 224),
+                image_dir=image_dir,
+                caption_dir=None,
+                batch_size=2,
+                dtype=np.float32,
+                model_type="clip",
+            )
+            assert dl.n_samples == 4
+
+    def test_handles_partial_batch(self):
+        """Test that partial batches are included."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            samples = [
+                ("img_0001.jpg", "caption 1"),
+                ("img_0002.jpg", "caption 2"),
+                ("img_0003.jpg", "caption 3"),
+            ]
+            image_dir, caption_dir = _create_retrieval_dataset(tmpdir, samples)
+
+            dl = CLIPRetrievalLoader(
+                shape=(3, 224, 224),
+                image_dir=image_dir,
+                caption_dir=caption_dir,
+                batch_size=2,
+                dtype=np.float32,
+                model_type="clip",
+            )
+            assert dl.n_samples == 3
+            assert dl.n_batches == 2
+
+    def test_missing_caption_skipped(self):
+        """Test that images without captions are skipped."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            samples = [
+                ("img_0001.jpg", "caption 1"),
+                ("img_0002.jpg", "caption 2"),
+                ("img_0003.jpg", "caption 3"),
+                ("img_0004.jpg", "caption 4"),
+            ]
+            image_dir, caption_dir = _create_retrieval_dataset(tmpdir, samples)
+
+            os.remove(os.path.join(caption_dir, "img_0001.txt"))
+
+            dl = CLIPRetrievalLoader(
+                shape=(3, 224, 224),
+                image_dir=image_dir,
+                caption_dir=caption_dir,
+                batch_size=1,
+                dtype=np.float32,
+                model_type="clip",
+            )
+            assert dl.n_samples == 3
+
+    def test_empty_caption_skipped(self):
+        """Test that images with empty captions are skipped."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            samples = [
+                ("img_0001.jpg", "caption 1"),
+                ("img_0002.jpg", ""),
+                ("img_0003.jpg", "caption 3"),
+                ("img_0004.jpg", "caption 4"),
+            ]
+            image_dir, caption_dir = _create_retrieval_dataset(tmpdir, samples)
+
+            dl = CLIPRetrievalLoader(
+                shape=(3, 224, 224),
+                image_dir=image_dir,
+                caption_dir=caption_dir,
+                batch_size=1,
+                dtype=np.float32,
+                model_type="clip",
+            )
+            assert dl.n_samples == 3
+
+
+class TestCLIPRetrievalLoaderIteration:
+    """Tests for CLIPRetrievalLoader __iter__ / __next__."""
+
+    @pytest.fixture
+    def loader(self, tmp_path):
+        """Create a test loader."""
+        samples = [
+            ("img_0001.jpg", "a photo of a cat"),
+            ("img_0002.jpg", "a photo of a dog"),
+            ("img_0003.jpg", "a photo of a bird"),
+            ("img_0004.jpg", "a photo of a fish"),
+            ("img_0005.jpg", "a photo of a horse"),
+            ("img_0006.jpg", "a photo of a cow"),
+            ("img_0007.jpg", "a photo of a sheep"),
+            ("img_0008.jpg", "a photo of a pig"),
+        ]
+        image_dir, caption_dir = _create_retrieval_dataset(str(tmp_path), samples)
+
+        return CLIPRetrievalLoader(
+            shape=(3, 32, 32),
+            image_dir=image_dir,
+            caption_dir=caption_dir,
+            batch_size=4,
+            dtype=np.float32,
+            model_type="clip",
+        )
+
+    def test_len(self, loader):
+        """Test __len__ returns correct number of batches."""
+        assert len(loader) == 2
+
+    def test_iter_returns_self(self, loader):
+        """Test __iter__ returns self."""
+        assert iter(loader) is loader
+
+    def test_batch_shapes(self, loader):
+        """Test that batches have correct shapes."""
+        for imgs, captions in loader:
+            assert imgs.shape == (4, 3, 32, 32)
+            assert len(captions) == 4
+            assert all(isinstance(c, str) for c in captions)
+
+    def test_pixel_range(self, loader):
+        """Test that pixel values are normalized (mean/std applied)."""
+        for imgs, _ in loader:
+            # After normalization, values can be negative and > 1
+            # Just verify they're in a reasonable range for normalized data
+            assert imgs.min() >= -3.0
+            assert imgs.max() <= 3.0
+
+    def test_captions_are_strings(self, loader):
+        """Test that captions are returned as strings."""
+        for _, captions in loader:
+            for caption in captions:
+                assert isinstance(caption, str)
+                assert len(caption) > 0
+
+    def test_iteration_count(self, loader):
+        """Test correct number of iterations."""
+        count = sum(1 for _ in loader)
+        assert count == 2
+
+    def test_reiter(self, loader):
+        """Verify loader can be iterated multiple times."""
+        first = sum(1 for _ in loader)
+        second = sum(1 for _ in loader)
+        assert first == second == 2
+
+    def test_partial_final_batch(self, tmp_path):
+        """Test that partial final batch is returned."""
+        samples = [
+            ("img_0001.jpg", "caption 1"),
+            ("img_0002.jpg", "caption 2"),
+            ("img_0003.jpg", "caption 3"),
+            ("img_0004.jpg", "caption 4"),
+            ("img_0005.jpg", "caption 5"),
+        ]
+        image_dir, caption_dir = _create_retrieval_dataset(str(tmp_path), samples)
+
+        dl = CLIPRetrievalLoader(
+            shape=(3, 32, 32),
+            image_dir=image_dir,
+            caption_dir=caption_dir,
+            batch_size=4,
+            dtype=np.float32,
+            model_type="clip",
+        )
+        assert dl.n_batches == 2
+
+        batches = list(dl)
+        assert len(batches) == 2
+        assert batches[0][0].shape[0] == 4
+        assert batches[1][0].shape[0] == 1
+
+    def test_resize_to_target(self, tmp_path):
+        """Images created at 64x64 should be resized to target shape."""
+        samples = [
+            ("img_0001.jpg", "caption 1"),
+            ("img_0002.jpg", "caption 2"),
+        ]
+        image_dir, caption_dir = _create_retrieval_dataset(str(tmp_path), samples)
+
+        dl = CLIPRetrievalLoader(
+            shape=(3, 128, 128),
+            image_dir=image_dir,
+            caption_dir=caption_dir,
+            batch_size=2,
+            dtype=np.float32,
+            model_type="clip",
+        )
+        imgs, _ = next(iter(dl))
+        assert imgs.shape == (2, 3, 128, 128)
+
+
+class TestCLIPRetrievalLoaderHelpers:
+    """Tests for CLIPRetrievalLoader helper methods."""
+
+    @pytest.fixture
+    def loader(self, tmp_path):
+        """Create a test loader."""
+        samples = [
+            ("img_0001.jpg", "caption 1"),
+            ("img_0002.jpg", "caption 2"),
+            ("img_0003.jpg", "caption 3"),
+            ("img_0004.jpg", "caption 4"),
+        ]
+        image_dir, caption_dir = _create_retrieval_dataset(str(tmp_path), samples)
+
+        return CLIPRetrievalLoader(
+            shape=(3, 32, 32),
+            image_dir=image_dir,
+            caption_dir=caption_dir,
+            batch_size=2,
+            dtype=np.float32,
+            model_type="clip",
+        )
+
+    def test_get_all_captions(self, loader):
+        """Test get_all_captions returns all captions."""
+        captions = loader.get_all_captions()
+        assert len(captions) == 4
+        assert all(isinstance(c, str) for c in captions)
+
+    def test_get_all_image_paths(self, loader):
+        """Test get_all_image_paths returns all paths."""
+        paths = loader.get_all_image_paths()
+        assert len(paths) == 4
+        assert all(os.path.exists(p) for p in paths)
+
+    def test_helpers_return_copies(self, loader):
+        """Test that helper methods return copies, not references."""
+        captions1 = loader.get_all_captions()
+        captions2 = loader.get_all_captions()
+        assert captions1 is not captions2
+
+        paths1 = loader.get_all_image_paths()
+        paths2 = loader.get_all_image_paths()
+        assert paths1 is not paths2
+
+
+class TestCLIPRetrievalLoaderCustomSuffix:
+    """Tests for custom caption file suffix."""
+
+    def test_custom_suffix(self, tmp_path):
+        """Test custom caption file suffix."""
+        image_dir = tmp_path / "images"
+        caption_dir = tmp_path / "captions"
+        image_dir.mkdir()
+        caption_dir.mkdir()
+
+        for i in range(4):
+            img = Image.fromarray(
+                np.random.randint(0, 255, (64, 64, 3), dtype=np.uint8)
+            )
+            img.save(image_dir / f"img_{i:04d}.png")
+
+            with open(
+                caption_dir / f"img_{i:04d}.caption", "w", encoding="utf-8"
+            ) as f:
+                f.write(f"caption {i}")
+
+        dl = CLIPRetrievalLoader(
+            shape=(3, 32, 32),
+            image_dir=str(image_dir),
+            caption_dir=str(caption_dir),
+            caption_file_suffix=".caption",
+            batch_size=2,
+            dtype=np.float32,
+            model_type="clip",
+        )
+        assert dl.n_samples == 4

--- a/tests/clip/test_engine_builder.py
+++ b/tests/clip/test_engine_builder.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLIP Engine Builder Unit Tests."""
+
+from unittest.mock import patch
+
+from nvidia_tao_deploy.multimodal.clip.engine_builder import CLIPEngineBuilder
+from nvidia_tao_deploy.engine.builder import EngineBuilder
+
+
+class TestCLIPEngineBuilderInit:
+    """Tests for CLIPEngineBuilder initialization."""
+
+    @patch.object(EngineBuilder, '__init__', return_value=None)
+    def test_default_data_format(self, mock_init):
+        builder = CLIPEngineBuilder()
+        assert builder._data_format == "channels_first"
+        mock_init.assert_called_once_with()
+
+    @patch.object(EngineBuilder, '__init__', return_value=None)
+    def test_custom_data_format(self, mock_init):
+        builder = CLIPEngineBuilder(data_format="channels_last")
+        assert builder._data_format == "channels_last"
+
+    @patch.object(EngineBuilder, '__init__', return_value=None)
+    def test_kwargs_forwarded(self, mock_init):
+        CLIPEngineBuilder(
+            data_format="channels_first",
+            workspace=4096,
+            max_batch_size=32,
+            strongly_typed=True,
+        )
+        mock_init.assert_called_once_with(
+            workspace=4096,
+            max_batch_size=32,
+            strongly_typed=True,
+        )
+
+    def test_inherits_engine_builder(self):
+        assert issubclass(CLIPEngineBuilder, EngineBuilder)

--- a/tests/clip/test_entrypoint.py
+++ b/tests/clip/test_entrypoint.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLIP Entrypoint Unit Tests."""
+
+from nvidia_tao_deploy.multimodal.clip.entrypoint.clip import get_subtask_list
+
+
+class TestGetSubtaskList:
+    """Tests for the CLIP entrypoint subtask discovery."""
+
+    def test_returns_dict(self):
+        subtasks = get_subtask_list()
+        assert isinstance(subtasks, dict)
+
+    def test_contains_gen_trt_engine(self):
+        subtasks = get_subtask_list()
+        assert "gen_trt_engine" in subtasks
+
+    def test_contains_evaluate(self):
+        subtasks = get_subtask_list()
+        assert "evaluate" in subtasks
+
+    def test_subtask_values_have_runner_path(self):
+        subtasks = get_subtask_list()
+        for details in subtasks.values():
+            assert isinstance(details, dict)
+            assert "runner_path" in details
+            assert details["runner_path"].endswith(".py")

--- a/tests/clip/test_evaluation.py
+++ b/tests/clip/test_evaluation.py
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLIP Evaluation Module Unit Tests."""
+
+import numpy as np
+import pytest
+
+from nvidia_tao_deploy.multimodal.clip.evaluation.metrics import (
+    compute_ap,
+    compute_auc,
+    compute_ndcg,
+)
+from nvidia_tao_deploy.multimodal.clip.evaluation.retrieval import (
+    RetrievalEvaluator,
+    RetrievalMetrics,
+)
+
+
+class TestComputeAP:
+    """Tests for compute_ap function."""
+
+    def test_perfect_ranking(self):
+        """All positives ranked first should give AP=1.0."""
+        labels = np.array([1, 1, 1, 0, 0, 0])
+        assert compute_ap(labels) == pytest.approx(1.0)
+
+    def test_worst_ranking(self):
+        """All positives ranked last should give low AP."""
+        labels = np.array([0, 0, 0, 1, 1, 1])
+        ap = compute_ap(labels)
+        assert ap < 0.5
+
+    def test_single_positive_first(self):
+        """Single positive ranked first."""
+        labels = np.array([1, 0, 0, 0, 0])
+        assert compute_ap(labels) == pytest.approx(1.0)
+
+    def test_single_positive_last(self):
+        """Single positive ranked last."""
+        labels = np.array([0, 0, 0, 0, 1])
+        assert compute_ap(labels) == pytest.approx(0.2)
+
+    def test_no_positives(self):
+        """No positives should return 0."""
+        labels = np.array([0, 0, 0, 0, 0])
+        assert compute_ap(labels) == 0.0
+
+    def test_all_positives(self):
+        """All positives should return 1.0."""
+        labels = np.array([1, 1, 1, 1, 1])
+        assert compute_ap(labels) == pytest.approx(1.0)
+
+    def test_mixed_ranking(self):
+        """Test with mixed ranking."""
+        labels = np.array([1, 0, 1, 0, 1, 0])
+        expected = (1/1 + 2/3 + 3/5) / 3
+        assert compute_ap(labels) == pytest.approx(expected)
+
+
+class TestComputeNDCG:
+    """Tests for compute_ndcg function."""
+
+    def test_perfect_ranking_k1(self):
+        """Perfect ranking at k=1."""
+        labels = np.array([1, 1, 0, 0, 0])
+        assert compute_ndcg(labels, k=1) == pytest.approx(1.0)
+
+    def test_perfect_ranking_k5(self):
+        """Perfect ranking at k=5."""
+        labels = np.array([1, 1, 1, 0, 0])
+        assert compute_ndcg(labels, k=5) == pytest.approx(1.0)
+
+    def test_no_positives(self):
+        """No positives should return 0."""
+        labels = np.array([0, 0, 0, 0, 0])
+        assert compute_ndcg(labels, k=5) == 0.0
+
+    def test_k_larger_than_array(self):
+        """k larger than array length should handle gracefully."""
+        labels = np.array([1, 0, 1])
+        ndcg = compute_ndcg(labels, k=10)
+        assert 0.0 <= ndcg <= 1.0
+
+    def test_positive_at_position_2(self):
+        """Single positive at position 2."""
+        labels = np.array([0, 1, 0, 0, 0])
+        ndcg = compute_ndcg(labels, k=5)
+        assert ndcg < 1.0
+        assert ndcg > 0.0
+
+
+class TestComputeAUC:
+    """Tests for compute_auc function."""
+
+    def test_perfect_separation(self):
+        """Perfect separation should give AUC=1.0."""
+        scores = np.array([0.9, 0.8, 0.7, 0.3, 0.2, 0.1])
+        labels = np.array([1, 1, 1, 0, 0, 0])
+        assert compute_auc(scores, labels) == pytest.approx(1.0)
+
+    def test_worst_separation(self):
+        """Worst separation should give AUC=0.0."""
+        scores = np.array([0.1, 0.2, 0.3, 0.7, 0.8, 0.9])
+        labels = np.array([1, 1, 1, 0, 0, 0])
+        assert compute_auc(scores, labels) == pytest.approx(0.0)
+
+    def test_random_separation(self):
+        """Random separation should give AUC around 0.5."""
+        np.random.seed(42)
+        scores = np.random.rand(100)
+        labels = np.array([1] * 50 + [0] * 50)
+        auc = compute_auc(scores, labels)
+        assert 0.3 < auc < 0.7
+
+    def test_no_positives(self):
+        """No positives should return 0.0."""
+        scores = np.array([0.9, 0.8, 0.7])
+        labels = np.array([0, 0, 0])
+        assert compute_auc(scores, labels) == 0.0
+
+    def test_no_negatives(self):
+        """No negatives should return 1.0."""
+        scores = np.array([0.9, 0.8, 0.7])
+        labels = np.array([1, 1, 1])
+        assert compute_auc(scores, labels) == 1.0
+
+
+class TestRetrievalMetrics:
+    """Tests for RetrievalMetrics dataclass."""
+
+    def test_default_values(self):
+        """Test default initialization."""
+        metrics = RetrievalMetrics()
+        assert metrics.map_score == 0.0
+        assert metrics.median_rank == 0.0
+        assert metrics.mean_rank == 0.0
+        assert metrics.auc == 0.0
+        assert metrics.num_queries == 0
+        assert metrics.gallery_size == 0
+        assert len(metrics.recall_at_k) == 0
+        assert len(metrics.ndcg_at_k) == 0
+
+    def test_to_dict(self):
+        """Test to_dict method."""
+        metrics = RetrievalMetrics(
+            recall_at_k={1: 0.5, 5: 0.8},
+            map_score=0.75,
+            median_rank=2.0,
+            mean_rank=3.5,
+            auc=0.9,
+            num_queries=100,
+            gallery_size=1000,
+        )
+        d = metrics.to_dict()
+        assert d['mAP'] == 0.75
+        assert d['median_rank'] == 2.0
+        assert d['mean_rank'] == 3.5
+        assert d['auc'] == 0.9
+        assert d['recall@1'] == 0.5
+        assert d['recall@5'] == 0.8
+
+    def test_str_representation(self):
+        """Test string representation."""
+        metrics = RetrievalMetrics(
+            recall_at_k={1: 0.5, 5: 0.8},
+            map_score=0.75,
+            median_rank=2.0,
+            mean_rank=3.5,
+            auc=0.9,
+            num_queries=100,
+            gallery_size=1000,
+        )
+        s = str(metrics)
+        assert "mAP: 0.7500" in s
+        assert "R@1: 0.5000" in s
+        assert "MedR: 2.0" in s
+
+
+class TestRetrievalEvaluator:
+    """Tests for RetrievalEvaluator class."""
+
+    def test_init_default(self):
+        """Test default initialization."""
+        evaluator = RetrievalEvaluator()
+        assert evaluator.k_values == (1, 5, 10)
+        assert evaluator._compute_auc is True
+        assert evaluator.batch_size == 1024
+
+    def test_init_custom(self):
+        """Test custom initialization."""
+        evaluator = RetrievalEvaluator(
+            k_values=(1, 3, 5),
+            compute_auc=False,
+            batch_size=512,
+        )
+        assert evaluator.k_values == (1, 3, 5)
+        assert evaluator._compute_auc is False
+        assert evaluator.batch_size == 512
+
+    def test_evaluate_perfect_matching(self):
+        """Test with perfect 1:1 matching."""
+        evaluator = RetrievalEvaluator()
+
+        n = 10
+        d = 64
+        embeddings = np.random.randn(n, d).astype(np.float32)
+        embeddings = embeddings / np.linalg.norm(embeddings, axis=1, keepdims=True)
+
+        gt = [[i] for i in range(n)]
+
+        metrics = evaluator.evaluate(embeddings, embeddings, gt)
+
+        assert metrics.recall_at_k[1] == pytest.approx(1.0)
+        assert metrics.map_score == pytest.approx(1.0)
+        assert metrics.median_rank == pytest.approx(1.0)
+
+    def test_evaluate_bidirectional(self):
+        """Test bidirectional evaluation."""
+        evaluator = RetrievalEvaluator()
+
+        n = 10
+        d = 64
+        image_embs = np.random.randn(n, d).astype(np.float32)
+        text_embs = image_embs.copy()
+
+        results = evaluator.evaluate_bidirectional(image_embs, text_embs)
+
+        assert 'image_to_text' in results
+        assert 'text_to_image' in results
+        assert results['image_to_text'].recall_at_k[1] == pytest.approx(1.0)
+        assert results['text_to_image'].recall_at_k[1] == pytest.approx(1.0)
+
+    def test_evaluate_with_ground_truth_matrix(self):
+        """Test with ground truth as matrix."""
+        evaluator = RetrievalEvaluator(k_values=(1, 2))
+
+        n = 5
+        d = 32
+        query_embs = np.random.randn(n, d).astype(np.float32)
+        gallery_embs = np.random.randn(n, d).astype(np.float32)
+
+        gt_matrix = np.eye(n)
+
+        metrics = evaluator.evaluate(query_embs, gallery_embs, gt_matrix)
+
+        assert metrics.num_queries == n
+        assert metrics.gallery_size == n
+
+    def test_evaluate_with_no_auc(self):
+        """Test evaluation without AUC computation."""
+        evaluator = RetrievalEvaluator(compute_auc=False)
+
+        n = 5
+        d = 32
+        embeddings = np.random.randn(n, d).astype(np.float32)
+        gt = [[i] for i in range(n)]
+
+        metrics = evaluator.evaluate(embeddings, embeddings, gt)
+
+        assert metrics.auc == 0.0

--- a/tests/clip/test_inferencer.py
+++ b/tests/clip/test_inferencer.py
@@ -1,0 +1,859 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLIP Inferencer Unit Tests."""
+
+import numpy as np
+import pytest
+import tensorrt as trt
+from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+
+from nvidia_tao_deploy.multimodal.clip.inferencer import (
+    CLIPInferencer,
+    CLIPSeparateInferencer,
+    _SingleEncoderInferencer,
+    create_clip_inferencer,
+    trt_output_process_fn,
+)
+from nvidia_tao_deploy.inferencer.trt_inferencer import TRTInferencer
+
+
+def _mock_output_tensors():
+    """Create mock output tensors for CLIP engine."""
+    return [
+        SimpleNamespace(tensor_name="image_embedding"),
+        SimpleNamespace(tensor_name="text_embedding"),
+        SimpleNamespace(tensor_name="logit_scale"),
+    ]
+
+
+def _mock_input_tensors():
+    """Create mock input tensors for CLIP engine."""
+    return [
+        SimpleNamespace(tensor_shape=(1, 3, 224, 224)),
+        SimpleNamespace(tensor_shape=(1, 77)),
+        SimpleNamespace(tensor_shape=(1, 77)),  # attention_mask
+    ]
+
+
+def _mock_output_tensors_with_bias():
+    """Create mock output tensors for CLIP engine including logit_bias."""
+    return [
+        SimpleNamespace(tensor_name="image_embedding"),
+        SimpleNamespace(tensor_name="text_embedding"),
+        SimpleNamespace(tensor_name="logit_scale"),
+        SimpleNamespace(tensor_name="logit_bias"),
+    ]
+
+
+def _mock_input_tensors_with_dtype():
+    """Create mock input tensors with tensor_dtype for property tests."""
+    return [
+        SimpleNamespace(tensor_shape=(1, 3, 224, 224), tensor_dtype=trt.float32),
+        SimpleNamespace(tensor_shape=(1, 77), tensor_dtype=trt.int32),
+        SimpleNamespace(tensor_shape=(1, 77), tensor_dtype=trt.int32),
+    ]
+
+
+def _mock_vision_output_tensors():
+    """Mock output tensors for a separate vision engine."""
+    return [
+        SimpleNamespace(tensor_name="image_embedding"),
+        SimpleNamespace(tensor_name="logit_scale"),
+        SimpleNamespace(tensor_name="logit_bias"),
+    ]
+
+
+def _mock_text_output_tensors():
+    """Mock output tensors for a separate text engine."""
+    return [
+        SimpleNamespace(tensor_name="text_embedding"),
+        SimpleNamespace(tensor_name="logit_scale"),
+        SimpleNamespace(tensor_name="logit_bias"),
+    ]
+
+
+def _setup_mock_inferencer(instance):
+    """Set up mock attributes on a CLIPInferencer instance after init."""
+    instance.output_tensors = _mock_output_tensors()
+    instance.input_tensors = _mock_input_tensors()
+    instance._copy_input_to_host = MagicMock()
+    instance.context = MagicMock()
+    instance.bindings = []
+    instance.inputs = []
+    instance.outputs = []
+    instance.stream = MagicMock()
+    instance.max_batch_size = 1
+    instance.execute_async = True
+    instance.trt_runtime = None
+    instance.engine = None
+
+
+def _make_mock_encoder(output_tensors, input_tensors):
+    """Create a mock _SingleEncoderInferencer with given IO tensors."""
+    mock = MagicMock(spec=_SingleEncoderInferencer)
+    mock.input_tensors = input_tensors
+    mock.output_tensors = output_tensors
+    names = [t.tensor_name for t in output_tensors]
+    mock.output_index.side_effect = lambda name: names.index(name)
+    return mock
+
+
+class TestTrtOutputProcessFn:
+    """Tests for trt_output_process_fn."""
+
+    def test_reshape_1d(self):
+        mock_output = SimpleNamespace(
+            host=np.array([1.0, 2.0, 3.0, 4.0]),
+            numpy_shape=(2, 2),
+        )
+        result = trt_output_process_fn(mock_output)
+        expected = np.array([[1.0, 2.0], [3.0, 4.0]])
+        np.testing.assert_array_equal(result, expected)
+
+    def test_reshape_batch_features(self):
+        data = np.arange(24, dtype=np.float32)
+        mock_output = SimpleNamespace(
+            host=data,
+            numpy_shape=(2, 3, 4),
+        )
+        result = trt_output_process_fn(mock_output)
+        assert result.shape == (2, 3, 4)
+        np.testing.assert_array_equal(result.flatten(), data)
+
+    def test_single_element(self):
+        mock_output = SimpleNamespace(
+            host=np.array([42.0]),
+            numpy_shape=(1,),
+        )
+        result = trt_output_process_fn(mock_output)
+        np.testing.assert_array_equal(result, np.array([42.0]))
+
+    def test_preserves_dtype(self):
+        mock_output = SimpleNamespace(
+            host=np.array([1, 2, 3, 4], dtype=np.float16),
+            numpy_shape=(2, 2),
+        )
+        result = trt_output_process_fn(mock_output)
+        assert result.dtype == np.float16
+
+
+class TestCLIPInferencerInit:
+    """Tests for CLIPInferencer initialization."""
+
+    def test_inherits_trt_inferencer(self):
+        assert issubclass(CLIPInferencer, TRTInferencer)
+
+    def test_default_params(self):
+        def mock_parent_init(self, *args, **kwargs):
+            self.output_tensors = _mock_output_tensors()
+            self.trt_runtime = None
+            self.context = None
+            self.engine = None
+            self.stream = None
+
+        with patch.object(TRTInferencer, '__init__', mock_parent_init):
+            infer = CLIPInferencer("/path/to/engine")
+            assert infer._output_names == [
+                "image_embedding", "text_embedding", "logit_scale"
+            ]
+
+    def test_custom_params(self):
+        def mock_parent_init(self, *args, **kwargs):
+            self.output_tensors = _mock_output_tensors()
+            self.trt_runtime = None
+            self.context = None
+            self.engine = None
+            self.stream = None
+
+        with patch.object(TRTInferencer, '__init__', mock_parent_init):
+            infer = CLIPInferencer(
+                "/path/to/engine",
+                input_shape=(1, 3, 224, 224),
+                batch_size=8,
+                data_format="channel_last",
+            )
+            assert infer._output_names == [
+                "image_embedding", "text_embedding", "logit_scale"
+            ]
+
+
+class TestCLIPInferencerInfer:
+    """Tests for CLIPInferencer.infer."""
+
+    def test_infer_single_output(self):
+        def mock_parent_init(self, *args, **kwargs):
+            self.output_tensors = _mock_output_tensors()
+            self.trt_runtime = None
+
+        with patch.object(TRTInferencer, '__init__', mock_parent_init):
+            infer = CLIPInferencer("/fake/engine")
+
+        _setup_mock_inferencer(infer)
+
+        mock_result = SimpleNamespace(
+            host=np.array([0.1, 0.2, 0.3], dtype=np.float32),
+            numpy_shape=(1, 3),
+        )
+
+        with patch(
+            'nvidia_tao_deploy.multimodal.clip.inferencer.do_inference',
+            return_value=[mock_result],
+        ):
+            imgs = np.random.rand(1, 3, 224, 224).astype(np.float32)
+            results = infer.infer(imgs)
+
+        assert len(results) == 1
+        assert results[0].shape == (1, 3)
+
+    def test_infer_multiple_outputs(self):
+        def mock_parent_init(self, *args, **kwargs):
+            self.output_tensors = _mock_output_tensors()
+            self.trt_runtime = None
+
+        with patch.object(TRTInferencer, '__init__', mock_parent_init):
+            infer = CLIPInferencer("/fake/engine")
+
+        _setup_mock_inferencer(infer)
+        infer.max_batch_size = 2
+
+        mock_img_features = SimpleNamespace(
+            host=np.arange(6, dtype=np.float32),
+            numpy_shape=(2, 3),
+        )
+        mock_text_features = SimpleNamespace(
+            host=np.arange(8, dtype=np.float32),
+            numpy_shape=(2, 4),
+        )
+
+        with patch(
+            'nvidia_tao_deploy.multimodal.clip.inferencer.do_inference',
+            return_value=[mock_img_features, mock_text_features],
+        ):
+            imgs = np.random.rand(2, 3, 224, 224).astype(np.float32)
+            results = infer.infer(imgs)
+
+        assert len(results) == 2
+        assert results[0].shape == (2, 3)
+        assert results[1].shape == (2, 4)
+
+    def test_infer_auto_creates_input_ids_and_attention_mask(self):
+        """Test that infer creates zero input_ids and ones attention_mask when not provided."""
+        def mock_parent_init(self, *args, **kwargs):
+            self.output_tensors = _mock_output_tensors()
+            self.trt_runtime = None
+
+        with patch.object(TRTInferencer, '__init__', mock_parent_init):
+            infer = CLIPInferencer("/fake/engine")
+
+        _setup_mock_inferencer(infer)
+
+        mock_result = SimpleNamespace(
+            host=np.zeros(3, dtype=np.float32),
+            numpy_shape=(1, 3),
+        )
+
+        with patch(
+            'nvidia_tao_deploy.multimodal.clip.inferencer.do_inference',
+            return_value=[mock_result],
+        ):
+            imgs = np.random.rand(1, 3, 224, 224).astype(np.float32)
+            infer.infer(imgs)
+
+        call_args = infer._copy_input_to_host.call_args[0][0]
+        assert len(call_args) == 3  # image, input_ids, attention_mask
+        assert call_args[1].shape == (1, 77)
+        assert call_args[1].dtype == np.int64
+        assert call_args[2].shape == (1, 77)  # attention_mask
+        assert call_args[2].dtype == np.int64
+        np.testing.assert_array_equal(call_args[2], np.ones((1, 77), dtype=np.int64))
+
+
+class TestCLIPInferencerEmbeddings:
+    """Tests for CLIPInferencer embedding extraction methods."""
+
+    def test_get_image_embeddings_normalized(self):
+        """Test that image embeddings are L2 normalized."""
+        def mock_parent_init(self, *args, **kwargs):
+            self.output_tensors = _mock_output_tensors()
+            self.trt_runtime = None
+
+        with patch.object(TRTInferencer, '__init__', mock_parent_init):
+            infer = CLIPInferencer("/fake/engine")
+
+        _setup_mock_inferencer(infer)
+
+        raw_feats = np.array([[3.0, 4.0]], dtype=np.float32)
+        mock_outputs = [
+            raw_feats,
+            np.zeros((1, 2)),
+            np.array([1.0]),
+        ]
+
+        with patch.object(infer, '_run', return_value=mock_outputs):
+            result = infer.get_image_embeddings(
+                np.zeros((1, 3, 224, 224), dtype=np.float32)
+            )
+
+        norm = np.linalg.norm(result, axis=-1)
+        np.testing.assert_allclose(norm, 1.0, rtol=1e-5)
+
+    def test_get_text_embeddings_normalized(self):
+        """Test that text embeddings are L2 normalized."""
+        def mock_parent_init(self, *args, **kwargs):
+            self.output_tensors = _mock_output_tensors()
+            self.trt_runtime = None
+
+        with patch.object(TRTInferencer, '__init__', mock_parent_init):
+            infer = CLIPInferencer("/fake/engine")
+
+        _setup_mock_inferencer(infer)
+
+        raw_feats = np.array([[5.0, 12.0]], dtype=np.float32)
+        mock_outputs = [
+            np.zeros((1, 2)),
+            raw_feats,
+            np.array([1.0]),
+        ]
+
+        with patch.object(infer, '_run', return_value=mock_outputs):
+            result = infer.get_text_embeddings(
+                np.zeros((1, 77), dtype=np.int64)
+            )
+
+        norm = np.linalg.norm(result, axis=-1)
+        np.testing.assert_allclose(norm, 1.0, rtol=1e-5)
+
+    def test_get_logit_scale(self):
+        """Test logit_scale extraction."""
+        def mock_parent_init(self, *args, **kwargs):
+            self.output_tensors = _mock_output_tensors()
+            self.trt_runtime = None
+
+        with patch.object(TRTInferencer, '__init__', mock_parent_init):
+            infer = CLIPInferencer("/fake/engine")
+
+        _setup_mock_inferencer(infer)
+
+        expected_scale = 4.6052
+        mock_outputs = [
+            np.zeros((1, 2)),
+            np.zeros((1, 2)),
+            np.array([[expected_scale]]),
+        ]
+
+        with patch.object(infer, '_run', return_value=mock_outputs):
+            result = infer.get_logit_scale()
+
+        assert isinstance(result, float)
+        np.testing.assert_allclose(result, expected_scale, rtol=1e-5)
+
+    def test_get_logit_bias(self):
+        """Test logit_bias extraction."""
+        def mock_parent_init(self, *args, **kwargs):
+            self.output_tensors = _mock_output_tensors_with_bias()
+            self.trt_runtime = None
+
+        with patch.object(TRTInferencer, '__init__', mock_parent_init):
+            infer = CLIPInferencer("/fake/engine")
+
+        _setup_mock_inferencer(infer)
+        infer.output_tensors = _mock_output_tensors_with_bias()
+        infer._output_names = [t.tensor_name for t in infer.output_tensors]
+
+        expected_bias = -10.0
+        mock_outputs = [
+            np.zeros((1, 2)),
+            np.zeros((1, 2)),
+            np.array([[4.6]]),
+            np.array([[expected_bias]]),
+        ]
+
+        with patch.object(infer, '_run', return_value=mock_outputs):
+            result = infer.get_logit_bias()
+
+        assert isinstance(result, float)
+        np.testing.assert_allclose(result, expected_bias, rtol=1e-5)
+
+
+class TestCLIPInferencerProperties:
+    """Tests for CLIPInferencer uniform accessor properties."""
+
+    def _make_infer(self):
+        def mock_parent_init(self, *args, **kwargs):
+            self.output_tensors = _mock_output_tensors_with_bias()
+            self.trt_runtime = None
+
+        with patch.object(TRTInferencer, '__init__', mock_parent_init):
+            infer = CLIPInferencer("/fake/engine")
+
+        infer.input_tensors = _mock_input_tensors_with_dtype()
+        infer.trt_runtime = None
+        infer.context = None
+        infer.engine = None
+        infer.stream = None
+        infer.inputs = []
+        infer.outputs = []
+        return infer
+
+    def test_image_input_shape(self):
+        infer = self._make_infer()
+        assert infer.image_input_shape == (3, 224, 224)
+
+    def test_image_input_dtype(self):
+        infer = self._make_infer()
+        assert infer.image_input_dtype == np.float32
+
+    def test_context_length(self):
+        infer = self._make_infer()
+        assert infer.context_length == 77
+
+
+# ======================================================================
+# CLIPSeparateInferencer tests
+# ======================================================================
+
+class TestCLIPSeparateInferencer:
+    """Tests for CLIPSeparateInferencer."""
+
+    def _make_separate_infer(self):
+        """Create a CLIPSeparateInferencer with mocked sub-engines."""
+        infer = CLIPSeparateInferencer.__new__(CLIPSeparateInferencer)
+        infer._vision = _make_mock_encoder(
+            _mock_vision_output_tensors(),
+            [SimpleNamespace(tensor_shape=(1, 3, 224, 224), tensor_dtype=trt.float32)],
+        )
+        infer._text = _make_mock_encoder(
+            _mock_text_output_tensors(),
+            [
+                SimpleNamespace(tensor_shape=(1, 77), tensor_dtype=trt.int32),
+                SimpleNamespace(tensor_shape=(1, 77), tensor_dtype=trt.int32),
+            ],
+        )
+        return infer
+
+    def test_image_input_shape(self):
+        infer = self._make_separate_infer()
+        assert infer.image_input_shape == (3, 224, 224)
+
+    def test_image_input_dtype(self):
+        infer = self._make_separate_infer()
+        assert infer.image_input_dtype == np.float32
+
+    def test_context_length(self):
+        infer = self._make_separate_infer()
+        assert infer.context_length == 77
+
+    def test_get_image_embeddings_normalized(self):
+        infer = self._make_separate_infer()
+        raw = np.array([[3.0, 4.0]], dtype=np.float32)
+        infer._vision.run.return_value = [
+            raw,
+            np.array([[4.6]], dtype=np.float32),
+            np.array([[-10.0]], dtype=np.float32),
+        ]
+
+        result = infer.get_image_embeddings(
+            np.zeros((1, 3, 224, 224), dtype=np.float32)
+        )
+        infer._vision.run.assert_called_once()
+        norm = np.linalg.norm(result, axis=-1)
+        np.testing.assert_allclose(norm, 1.0, rtol=1e-5)
+
+    def test_get_text_embeddings_normalized(self):
+        infer = self._make_separate_infer()
+        raw = np.array([[5.0, 12.0]], dtype=np.float32)
+        infer._text.run.return_value = [
+            raw,
+            np.array([[4.6]], dtype=np.float32),
+            np.array([[-10.0]], dtype=np.float32),
+        ]
+
+        result = infer.get_text_embeddings(
+            np.zeros((1, 77), dtype=np.int64)
+        )
+        infer._text.run.assert_called_once()
+        norm = np.linalg.norm(result, axis=-1)
+        np.testing.assert_allclose(norm, 1.0, rtol=1e-5)
+
+    def test_get_logit_scale(self):
+        infer = self._make_separate_infer()
+        expected = 4.6052
+        infer._vision.run.return_value = [
+            np.zeros((1, 2), dtype=np.float32),
+            np.array([[expected]], dtype=np.float32),
+            np.array([[-10.0]], dtype=np.float32),
+        ]
+        result = infer.get_logit_scale()
+        assert isinstance(result, float)
+        np.testing.assert_allclose(result, expected, rtol=1e-5)
+
+    def test_get_logit_bias(self):
+        infer = self._make_separate_infer()
+        expected = -10.0
+        infer._vision.run.return_value = [
+            np.zeros((1, 2), dtype=np.float32),
+            np.array([[4.6]], dtype=np.float32),
+            np.array([[expected]], dtype=np.float32),
+        ]
+        result = infer.get_logit_bias()
+        assert isinstance(result, float)
+        np.testing.assert_allclose(result, expected, rtol=1e-5)
+
+    def test_image_only_does_not_touch_text_engine(self):
+        """Vision-only inference should never call the text engine."""
+        infer = self._make_separate_infer()
+        infer._vision.run.return_value = [
+            np.array([[1.0, 0.0]], dtype=np.float32),
+            np.array([[4.6]], dtype=np.float32),
+            np.array([[-10.0]], dtype=np.float32),
+        ]
+        infer.get_image_embeddings(np.zeros((1, 3, 224, 224), dtype=np.float32))
+        infer._text.run.assert_not_called()
+
+    def test_text_only_does_not_touch_vision_engine(self):
+        """Text-only inference should never call the vision engine."""
+        infer = self._make_separate_infer()
+        infer._text.run.return_value = [
+            np.array([[0.0, 1.0]], dtype=np.float32),
+            np.array([[4.6]], dtype=np.float32),
+            np.array([[-10.0]], dtype=np.float32),
+        ]
+        infer.get_text_embeddings(np.zeros((1, 77), dtype=np.int64))
+        infer._vision.run.assert_not_called()
+
+    # --- Single-pillar mode tests ---
+
+    def test_vision_only_mode(self):
+        """Vision-only inferencer can extract image embeddings."""
+        infer = CLIPSeparateInferencer.__new__(CLIPSeparateInferencer)
+        infer._vision = _make_mock_encoder(
+            _mock_vision_output_tensors(),
+            [SimpleNamespace(tensor_shape=(1, 3, 224, 224), tensor_dtype=trt.float32)],
+        )
+        infer._text = None
+
+        assert infer.has_vision
+        assert not infer.has_text
+        assert infer.image_input_shape == (3, 224, 224)
+        assert infer.context_length is None
+
+        infer._vision.run.return_value = [
+            np.array([[3.0, 4.0]], dtype=np.float32),
+            np.array([[4.6]], dtype=np.float32),
+            np.array([[-10.0]], dtype=np.float32),
+        ]
+        result = infer.get_image_embeddings(
+            np.zeros((1, 3, 224, 224), dtype=np.float32)
+        )
+        assert result.shape == (1, 2)
+
+    def test_vision_only_text_raises(self):
+        """Vision-only inferencer raises on text embedding request."""
+        infer = CLIPSeparateInferencer.__new__(CLIPSeparateInferencer)
+        infer._vision = _make_mock_encoder(
+            _mock_vision_output_tensors(),
+            [SimpleNamespace(tensor_shape=(1, 3, 224, 224), tensor_dtype=trt.float32)],
+        )
+        infer._text = None
+
+        with pytest.raises(RuntimeError, match="Text engine not loaded"):
+            infer.get_text_embeddings(np.zeros((1, 77), dtype=np.int64))
+
+    def test_text_only_mode(self):
+        """Text-only inferencer can extract text embeddings."""
+        infer = CLIPSeparateInferencer.__new__(CLIPSeparateInferencer)
+        infer._vision = None
+        infer._text = _make_mock_encoder(
+            _mock_text_output_tensors(),
+            [
+                SimpleNamespace(tensor_shape=(1, 77), tensor_dtype=trt.int32),
+                SimpleNamespace(tensor_shape=(1, 77), tensor_dtype=trt.int32),
+            ],
+        )
+
+        assert not infer.has_vision
+        assert infer.has_text
+        assert infer.image_input_shape is None
+        assert infer.context_length == 77
+
+        infer._text.run.return_value = [
+            np.array([[5.0, 12.0]], dtype=np.float32),
+            np.array([[4.6]], dtype=np.float32),
+            np.array([[-10.0]], dtype=np.float32),
+        ]
+        result = infer.get_text_embeddings(np.zeros((1, 77), dtype=np.int64))
+        assert result.shape == (1, 2)
+
+    def test_text_only_image_raises(self):
+        """Text-only inferencer raises on image embedding request."""
+        infer = CLIPSeparateInferencer.__new__(CLIPSeparateInferencer)
+        infer._vision = None
+        infer._text = _make_mock_encoder(
+            _mock_text_output_tensors(),
+            [SimpleNamespace(tensor_shape=(1, 77), tensor_dtype=trt.int32)],
+        )
+
+        with pytest.raises(RuntimeError, match="Vision engine not loaded"):
+            infer.get_image_embeddings(
+                np.zeros((1, 3, 224, 224), dtype=np.float32)
+            )
+
+    def test_both_none_raises(self):
+        """Passing both paths as None raises ValueError."""
+        with pytest.raises(ValueError, match="At least one engine"):
+            CLIPSeparateInferencer(
+                vision_engine_path=None, text_engine_path=None
+            )
+
+
+# ======================================================================
+# _SingleEncoderInferencer tests
+# ======================================================================
+
+class TestSingleEncoderInferencer:
+    """Tests for _SingleEncoderInferencer."""
+
+    def test_inherits_trt_inferencer(self):
+        assert issubclass(_SingleEncoderInferencer, TRTInferencer)
+
+    def test_output_index(self):
+        def mock_parent_init(self, *args, **kwargs):
+            self.output_tensors = _mock_vision_output_tensors()
+            self.trt_runtime = None
+            self.context = None
+            self.engine = None
+            self.stream = None
+            self.inputs = []
+            self.outputs = []
+
+        with patch.object(TRTInferencer, '__init__', mock_parent_init):
+            enc = _SingleEncoderInferencer("/fake/engine")
+
+        assert enc.output_index("image_embedding") == 0
+        assert enc.output_index("logit_scale") == 1
+        assert enc.output_index("logit_bias") == 2
+
+    def test_infer_raises(self):
+        """The abstract infer() should raise — callers must use run()."""
+        def mock_parent_init(self, *args, **kwargs):
+            self.output_tensors = _mock_vision_output_tensors()
+            self.trt_runtime = None
+            self.context = None
+            self.engine = None
+            self.stream = None
+            self.inputs = []
+            self.outputs = []
+
+        with patch.object(TRTInferencer, '__init__', mock_parent_init):
+            enc = _SingleEncoderInferencer("/fake/engine")
+
+        with pytest.raises(NotImplementedError):
+            enc.infer(np.zeros((1, 3, 224, 224)))
+
+
+# ======================================================================
+# create_clip_inferencer factory tests
+# ======================================================================
+
+def _noop_trt_init(self, *args, **kwargs):
+    """No-op TRTInferencer.__init__ that sets all required attributes."""
+    self.output_tensors = []
+    self.input_tensors = []
+    self.trt_runtime = None
+    self.context = None
+    self.engine = None
+    self.stream = None
+    self.inputs = []
+    self.outputs = []
+
+
+def _combined_trt_init(self, *args, **kwargs):
+    """Mock TRTInferencer.__init__ that sets combined-engine attributes."""
+    self.output_tensors = _mock_output_tensors()
+    self.input_tensors = _mock_input_tensors()
+    self.trt_runtime = None
+    self.context = None
+    self.engine = None
+    self.stream = None
+    self.inputs = []
+    self.outputs = []
+
+
+class TestCreateClipInferencer:
+    """Tests for the create_clip_inferencer factory function."""
+
+    # --- Case 1: combined engine file ---
+
+    def test_combined_engine(self, tmp_path):
+        """Factory returns CLIPInferencer when a single engine file exists."""
+        engine = tmp_path / "model.engine"
+        engine.write_bytes(b"fake")
+
+        with patch.object(TRTInferencer, '__init__', _combined_trt_init):
+            result = create_clip_inferencer(str(engine))
+        assert isinstance(result, CLIPInferencer)
+
+    # --- Case 2: base path, _vision + _text discovered ---
+
+    def test_separate_engines(self, tmp_path):
+        """Factory returns CLIPSeparateInferencer when _vision/_text exist."""
+        (tmp_path / "model_vision.engine").write_bytes(b"fake")
+        (tmp_path / "model_text.engine").write_bytes(b"fake")
+
+        with patch.object(TRTInferencer, '__init__', _noop_trt_init):
+            result = create_clip_inferencer(
+                str(tmp_path / "model.engine")
+            )
+        assert isinstance(result, CLIPSeparateInferencer)
+
+    # --- Case 3: user points to _vision or _text directly ---
+
+    def test_point_to_vision_finds_pair(self, tmp_path):
+        """Pointing to _vision engine auto-discovers _text partner."""
+        (tmp_path / "model_vision.engine").write_bytes(b"fake")
+        (tmp_path / "model_text.engine").write_bytes(b"fake")
+
+        with patch.object(TRTInferencer, '__init__', _noop_trt_init):
+            result = create_clip_inferencer(
+                str(tmp_path / "model_vision.engine")
+            )
+        assert isinstance(result, CLIPSeparateInferencer)
+
+    def test_point_to_text_finds_pair(self, tmp_path):
+        """Pointing to _text engine auto-discovers _vision partner."""
+        (tmp_path / "model_vision.engine").write_bytes(b"fake")
+        (tmp_path / "model_text.engine").write_bytes(b"fake")
+
+        with patch.object(TRTInferencer, '__init__', _noop_trt_init):
+            result = create_clip_inferencer(
+                str(tmp_path / "model_text.engine")
+            )
+        assert isinstance(result, CLIPSeparateInferencer)
+
+    def test_point_to_vision_only(self, tmp_path):
+        """Pointing to _vision without _text gives vision-only inferencer."""
+        (tmp_path / "model_vision.engine").write_bytes(b"fake")
+
+        with patch.object(TRTInferencer, '__init__', _noop_trt_init):
+            result = create_clip_inferencer(
+                str(tmp_path / "model_vision.engine")
+            )
+        assert isinstance(result, CLIPSeparateInferencer)
+        assert result.has_vision
+        assert not result.has_text
+
+    def test_point_to_text_only(self, tmp_path):
+        """Pointing to _text without _vision gives text-only inferencer."""
+        (tmp_path / "model_text.engine").write_bytes(b"fake")
+
+        with patch.object(TRTInferencer, '__init__', _noop_trt_init):
+            result = create_clip_inferencer(
+                str(tmp_path / "model_text.engine")
+            )
+        assert isinstance(result, CLIPSeparateInferencer)
+        assert not result.has_vision
+        assert result.has_text
+
+    # --- Case 4: directory path ---
+
+    def test_directory_with_separate_engines(self, tmp_path):
+        """Pointing to directory discovers separate engine pair."""
+        (tmp_path / "model_vision.engine").write_bytes(b"fake")
+        (tmp_path / "model_text.engine").write_bytes(b"fake")
+
+        with patch.object(TRTInferencer, '__init__', _noop_trt_init):
+            result = create_clip_inferencer(str(tmp_path))
+        assert isinstance(result, CLIPSeparateInferencer)
+
+    def test_directory_with_combined_engine(self, tmp_path):
+        """Pointing to directory discovers combined engine."""
+        (tmp_path / "model.engine").write_bytes(b"fake")
+
+        with patch.object(TRTInferencer, '__init__', _combined_trt_init):
+            result = create_clip_inferencer(str(tmp_path))
+        assert isinstance(result, CLIPInferencer)
+
+    def test_directory_prefers_separate_over_combined(self, tmp_path):
+        """Directory with both separate and combined prefers separate."""
+        (tmp_path / "model.engine").write_bytes(b"fake")
+        (tmp_path / "model_vision.engine").write_bytes(b"fake")
+        (tmp_path / "model_text.engine").write_bytes(b"fake")
+
+        with patch.object(TRTInferencer, '__init__', _noop_trt_init):
+            result = create_clip_inferencer(str(tmp_path))
+        assert isinstance(result, CLIPSeparateInferencer)
+
+    def test_directory_with_vision_only(self, tmp_path):
+        """Directory with only _vision engine gives vision-only inferencer."""
+        (tmp_path / "model_vision.engine").write_bytes(b"fake")
+
+        with patch.object(TRTInferencer, '__init__', _noop_trt_init):
+            result = create_clip_inferencer(str(tmp_path))
+        assert isinstance(result, CLIPSeparateInferencer)
+        assert result.has_vision
+        assert not result.has_text
+
+    def test_directory_with_text_only(self, tmp_path):
+        """Directory with only _text engine gives text-only inferencer."""
+        (tmp_path / "model_text.engine").write_bytes(b"fake")
+
+        with patch.object(TRTInferencer, '__init__', _noop_trt_init):
+            result = create_clip_inferencer(str(tmp_path))
+        assert isinstance(result, CLIPSeparateInferencer)
+        assert not result.has_vision
+        assert result.has_text
+
+    def test_empty_directory_raises(self, tmp_path):
+        """Empty directory raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError, match="No .engine files"):
+            create_clip_inferencer(str(tmp_path))
+
+    # --- Case 7: combined preferred when explicitly pointed at ---
+
+    def test_prefers_combined_when_both_exist(self, tmp_path):
+        """If both combined and separate files exist, combined wins
+        when user explicitly points to the combined file."""
+        (tmp_path / "model.engine").write_bytes(b"fake")
+        (tmp_path / "model_vision.engine").write_bytes(b"fake")
+        (tmp_path / "model_text.engine").write_bytes(b"fake")
+
+        with patch.object(TRTInferencer, '__init__', _combined_trt_init):
+            result = create_clip_inferencer(str(tmp_path / "model.engine"))
+        assert isinstance(result, CLIPInferencer)
+
+    # --- Error cases ---
+
+    def test_no_engine_raises_file_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="TRT engine not found"):
+            create_clip_inferencer(str(tmp_path / "nonexistent.engine"))
+
+    def test_error_message_lists_checked_paths(self, tmp_path):
+        base = str(tmp_path / "model.engine")
+        with pytest.raises(FileNotFoundError) as exc_info:
+            create_clip_inferencer(base)
+        msg = str(exc_info.value)
+        assert "model.engine" in msg
+        assert "model_vision.engine" in msg
+        assert "model_text.engine" in msg
+
+    def test_only_vision_engine_via_base_path(self, tmp_path):
+        """Having only _vision via base path gives vision-only inferencer."""
+        (tmp_path / "model_vision.engine").write_bytes(b"fake")
+
+        with patch.object(TRTInferencer, '__init__', _noop_trt_init):
+            result = create_clip_inferencer(str(tmp_path / "model.engine"))
+        assert isinstance(result, CLIPSeparateInferencer)
+        assert result.has_vision
+        assert not result.has_text
+
+    def test_only_text_engine_via_base_path(self, tmp_path):
+        """Having only _text via base path gives text-only inferencer."""
+        (tmp_path / "model_text.engine").write_bytes(b"fake")
+
+        with patch.object(TRTInferencer, '__init__', _noop_trt_init):
+            result = create_clip_inferencer(str(tmp_path / "model.engine"))
+        assert isinstance(result, CLIPSeparateInferencer)
+        assert not result.has_vision
+        assert result.has_text

--- a/tests/core/__init__.py
+++ b/tests/core/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Core Unit Tests."""

--- a/tests/core/test_decrypt.py
+++ b/tests/core/test_decrypt.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests to decrpyt models."""
+
+import pytest
+import os
+from nvidia_tao_deploy.utils.decoding import decode_model
+
+
+@pytest.mark.core
+@pytest.mark.parametrize("model_path", ["/home/scratch.metropolis2/tao_ci/tao_deploy/models/efficientdet_tf1/model.step-39060_trt825.etlt"])
+@pytest.mark.parametrize("model_key", ["nvidia_tlt"])
+def test_decode_model(model_path, model_key):
+    tmp_onnx_file, file_format = decode_model(model_path, model_key)
+
+    assert os.path.exists(tmp_onnx_file)
+    assert file_format == "onnx"

--- a/tests/core/test_dual_logging.py
+++ b/tests/core/test_dual_logging.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for dual logging functionality in TAO Deploy."""
+
+import json
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from nvidia_tao_deploy.cv.common.logging.tlt_logging import logging, logger, StatusLoggerHandler
+from nvidia_tao_deploy.cv.common.logging.status_logging import StatusLogger, set_status_logger, get_status_logger
+
+
+@pytest.fixture
+def temp_log_dir():
+    """Create a temporary directory for log files."""
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+    # Cleanup temporary directory
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def reset_logger():
+    """Reset logger handlers after each test."""
+    # Store original handlers
+    original_handlers = logger.handlers.copy()
+
+    yield
+
+    # Restore original handlers
+    logger.handlers = original_handlers
+
+
+def test_status_logger_handler_added_once(temp_log_dir, reset_logger):
+    """Test that StatusLoggerHandler is only added once, even with multiple set_status_logger calls."""
+    # Create first status logger
+    status_log_1 = os.path.join(temp_log_dir, "status1.json")
+    set_status_logger(StatusLogger(filename=status_log_1, is_master=True, verbosity=10, append=False))
+
+    # Count StatusLoggerHandler instances
+    status_handlers_1 = [h for h in logger.handlers if isinstance(h, StatusLoggerHandler)]
+    assert len(status_handlers_1) == 1, "Should have exactly one StatusLoggerHandler after first set_status_logger"
+
+    # Create second status logger
+    status_log_2 = os.path.join(temp_log_dir, "status2.json")
+    set_status_logger(StatusLogger(filename=status_log_2, is_master=True, verbosity=10, append=False))
+
+    # Count StatusLoggerHandler instances again
+    status_handlers_2 = [h for h in logger.handlers if isinstance(h, StatusLoggerHandler)]
+    assert len(status_handlers_2) == 1, "Should still have exactly one StatusLoggerHandler after second set_status_logger"
+
+    # Verify it's the same handler instance
+    assert status_handlers_1[0] is status_handlers_2[0], "Should be the same handler instance"
+
+
+def test_dual_logging_writes_to_both_outputs(temp_log_dir, reset_logger, monkeypatch):
+    """Test that log messages are written to both console and status file."""
+    # Set logging level to DEBUG to capture all messages
+    monkeypatch.setenv('TAO_LOGGING_LEVEL', 'DEBUG')
+    
+    # Reconfigure logger with DEBUG level
+    from nvidia_tao_deploy.cv.common.logging.tlt_logging import get_logging_level
+    new_level = get_logging_level()
+    logger.setLevel(new_level)
+    for handler in logger.handlers:
+        handler.setLevel(new_level)
+    
+    status_log_file = os.path.join(temp_log_dir, "status.json")
+
+    # Setup status logger (automatically enables dual logging)
+    set_status_logger(StatusLogger(filename=status_log_file, is_master=True, verbosity=10, append=False))
+
+    # Write various log levels
+    test_messages = [
+        ("debug", "Test DEBUG message"),
+        ("info", "Test INFO message"),
+        ("warning", "Test WARNING message"),
+        ("error", "Test ERROR message"),
+    ]
+
+    for level, message in test_messages:
+        getattr(logging, level)(message)
+
+    # Verify status file exists and contains the messages
+    assert os.path.exists(status_log_file), "Status log file should exist"
+
+    with open(status_log_file, 'r') as f:
+        lines = f.readlines()
+
+    assert len(lines) >= len(test_messages), f"Status file should have at least {len(test_messages)} entries"
+
+    # Parse and verify messages
+    found_messages = []
+    for line in lines:
+        try:
+            data = json.loads(line.strip())
+            if 'message' in data:
+                found_messages.append(data['message'])
+        except json.JSONDecodeError:
+            pass
+
+    # Check that our test messages appear in the log
+    for level, expected_msg in test_messages:
+        assert any(expected_msg in msg for msg in found_messages), \
+            f"Expected message '{expected_msg}' not found in status log"
+
+
+def test_status_logger_switching(temp_log_dir, reset_logger):
+    """Test that switching status loggers routes messages to the current logger."""
+    # Setup first status logger
+    status_log_1 = os.path.join(temp_log_dir, "status1.json")
+    set_status_logger(StatusLogger(filename=status_log_1, is_master=True, verbosity=10, append=False))
+
+    # Write to first logger
+    logging.info("Message to first logger")
+
+    # Switch to second status logger
+    status_log_2 = os.path.join(temp_log_dir, "status2.json")
+    set_status_logger(StatusLogger(filename=status_log_2, is_master=True, verbosity=10, append=False))
+
+    # Write to second logger
+    logging.info("Message to second logger")
+
+    # Switch to third status logger
+    status_log_3 = os.path.join(temp_log_dir, "status3.json")
+    set_status_logger(StatusLogger(filename=status_log_3, is_master=True, verbosity=10, append=False))
+
+    # Write to third logger
+    logging.info("Message to third logger")
+
+    # Verify all files exist
+    assert os.path.exists(status_log_1), "First status log should exist"
+    assert os.path.exists(status_log_2), "Second status log should exist"
+    assert os.path.exists(status_log_3), "Third status log should exist"
+
+    # Verify the third logger is currently active
+    assert get_status_logger().log_path == status_log_3, "Third status logger should be active"
+
+    # Helper function to extract messages from a log file
+    def get_messages_from_log(log_file):
+        messages = []
+        if os.path.exists(log_file):
+            with open(log_file, 'r') as f:
+                for line in f:
+                    try:
+                        data = json.loads(line.strip())
+                        if 'message' in data:
+                            messages.append(data['message'])
+                    except json.JSONDecodeError:
+                        pass
+        return messages
+
+    # Get messages from each log
+    messages_1 = get_messages_from_log(status_log_1)
+    messages_2 = get_messages_from_log(status_log_2)
+    messages_3 = get_messages_from_log(status_log_3)
+
+    # Verify messages went to the right logs
+    assert any("Message to first logger" in msg for msg in messages_1), \
+        "First log should contain 'Message to first logger'"
+    assert any("Message to second logger" in msg for msg in messages_2), \
+        "Second log should contain 'Message to second logger'"
+    assert any("Message to third logger" in msg for msg in messages_3), \
+        "Third log should contain 'Message to third logger'"
+
+
+def test_log_level_mapping(temp_log_dir, reset_logger, monkeypatch):
+    """Test that Python logging levels are correctly mapped to StatusLogger verbosity levels."""
+    # Set logging level to DEBUG to capture all messages
+    monkeypatch.setenv('TAO_LOGGING_LEVEL', 'DEBUG')
+    
+    # Reconfigure logger with DEBUG level
+    from nvidia_tao_deploy.cv.common.logging.tlt_logging import get_logging_level
+    new_level = get_logging_level()
+    logger.setLevel(new_level)
+    for handler in logger.handlers:
+        handler.setLevel(new_level)
+    
+    status_log_file = os.path.join(temp_log_dir, "status.json")
+    set_status_logger(StatusLogger(filename=status_log_file, is_master=True, verbosity=10, append=False))
+
+    # Test different log levels
+    logging.debug("Debug message")
+    logging.info("Info message")
+    logging.warning("Warning message")
+    logging.error("Error message")
+    logging.critical("Critical message")
+
+    # Read and parse the log file
+    with open(status_log_file, 'r') as f:
+        entries = [json.loads(line.strip()) for line in f if line.strip()]
+
+    # Verify that entries have the correct verbosity and status levels
+    assert len(entries) >= 5, "Should have at least 5 log entries"
+
+    # Check that error and critical messages have FAILURE status
+    error_entries = [e for e in entries if 'Error message' in e.get('message', '')]
+    critical_entries = [e for e in entries if 'Critical message' in e.get('message', '')]
+
+    if error_entries:
+        assert error_entries[0]['status'] == 'FAILURE', "Error messages should have FAILURE status"
+    if critical_entries:
+        assert critical_entries[0]['status'] == 'FAILURE', "Critical messages should have FAILURE status"
+
+    # Check that other messages have RUNNING status
+    info_entries = [e for e in entries if 'Info message' in e.get('message', '')]
+    if info_entries:
+        assert info_entries[0]['status'] == 'RUNNING', "Info messages should have RUNNING status"
+
+
+def test_dual_logging_silent_on_multiple_calls(temp_log_dir, reset_logger, caplog):
+    """Test that multiple set_status_logger calls don't generate warnings."""
+    import logging as std_logging
+
+    # Set logging level to capture warnings
+    caplog.set_level(std_logging.WARNING)
+
+    # Make multiple calls
+    for i in range(3):
+        status_log = os.path.join(temp_log_dir, f"status{i}.json")
+        set_status_logger(StatusLogger(filename=status_log, is_master=True, verbosity=10, append=False))
+
+    # Check that no warnings about duplicate handlers were logged
+    duplicate_handler_warnings = [
+        record for record in caplog.records
+        if "StatusLoggerHandler already added" in record.getMessage()
+    ]
+
+    assert len(duplicate_handler_warnings) == 0, \
+        "Should not generate warnings about duplicate handlers"
+
+
+def test_status_logger_handler_fetches_current_logger(temp_log_dir, reset_logger):
+    """Test that StatusLoggerHandler always uses the current status logger."""
+    # This is implicitly tested in test_status_logger_switching,
+    # but we'll verify the handler behavior more directly
+
+    status_log_1 = os.path.join(temp_log_dir, "handler_test_1.json")
+    status_log_2 = os.path.join(temp_log_dir, "handler_test_2.json")
+
+    # Set first logger
+    set_status_logger(StatusLogger(filename=status_log_1, is_master=True, verbosity=10, append=False))
+    current_logger_1 = get_status_logger()
+
+    # Get the handler
+    status_handlers = [h for h in logger.handlers if isinstance(h, StatusLoggerHandler)]
+    assert len(status_handlers) == 1
+    handler = status_handlers[0]
+
+    # Set second logger
+    set_status_logger(StatusLogger(filename=status_log_2, is_master=True, verbosity=10, append=False))
+    current_logger_2 = get_status_logger()
+
+    # Verify the status logger changed
+    assert current_logger_1 is not current_logger_2, "Status loggers should be different instances"
+    assert current_logger_1.log_path != current_logger_2.log_path, "Status loggers should have different paths"
+
+    # Verify handler is still the same instance
+    status_handlers_after = [h for h in logger.handlers if isinstance(h, StatusLoggerHandler)]
+    assert len(status_handlers_after) == 1
+    assert status_handlers_after[0] is handler, "Handler should be the same instance"
+
+    # Write a message - it should go to the second logger
+    logging.info("Test message to verify handler uses current logger")
+
+    # Verify the message went to the second log file
+    with open(status_log_2, 'r') as f:
+        lines = f.readlines()
+
+    messages = []
+    for line in lines:
+        try:
+            data = json.loads(line.strip())
+            if 'message' in data:
+                messages.append(data['message'])
+        except json.JSONDecodeError:
+            pass
+
+    assert any("Test message to verify handler uses current logger" in msg for msg in messages), \
+        "Message should appear in the second log file"
+

--- a/tests/deformable_detr/__init__.py
+++ b/tests/deformable_detr/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deformable DETR Unit Tests."""

--- a/tests/deformable_detr/test_dataloader.py
+++ b/tests/deformable_detr/test_dataloader.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""D-DETR Data Loading Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+import json
+from PIL import Image
+import tempfile
+
+from nvidia_tao_deploy.cv.deformable_detr.dataloader import DDETRCOCOLoader
+
+
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+COCO_DICT = {
+    "images": [
+        {
+            "license": 1,
+            "file_name": "000000552775.jpg",
+            "coco_url": "http://images.cocodataset.org/val2017/000000552775.jpg",
+            "height": 500,
+            "width": 375,
+            "id": 552775
+        },
+        {
+            "license": 3,
+            "file_name": "000000394940.jpg",
+            "coco_url": "http://images.cocodataset.org/val2017/000000394940.jpg",
+            "height": 640,
+            "width": 426,
+            "id": 394940
+        },
+        {
+            "license": 2,
+            "file_name": "000000015335.jpg",
+            "coco_url": "http://images.cocodataset.org/val2017/000000015335.jpg",
+            "height": 480,
+            "width": 640,            
+            "id": 15335
+        }
+    ],
+    "annotations": [
+        {
+            "area": 475.48160000000036,
+            "iscrowd": 0,
+            "image_id": 552775,
+            "bbox": [
+                286.65,
+                96.17,
+                19.33,
+                27.98
+            ],
+            "category_id": 1,
+            "id": 83208
+        },
+        {
+            "area": 384.27450000000016,
+            "iscrowd": 0,
+            "image_id": 552775,
+            "bbox": [
+                251.46,
+                93.75,
+                19.76,
+                29.02
+            ],
+            "category_id": 2,
+            "id": 93799
+        },
+        {
+            "area": 14986.082449999996,
+            "iscrowd": 0,
+            "image_id": 552775,
+            "bbox": [
+                1.87,
+                133.08,
+                94.02,
+                204.39
+            ],
+            "category_id": 1,
+            "id": 1749992
+        },
+        {
+            "area": 114105.64780000002,
+            "iscrowd": 0,
+            "image_id": 394940,
+            "bbox": [
+                0.0,
+                77.18,
+                425.79,
+                413.66
+            ],
+            "category_id": 1,
+            "id": 2164128
+        },
+        {
+            "area": 56257.02764999998,
+            "iscrowd": 0,
+            "image_id": 15335,
+            "bbox": [
+                365.92,
+                15.07,
+                274.08,
+                458.47
+            ],
+            "category_id": 1,
+            "id": 1216332
+        },
+        {
+            "area": 44578.0246,
+            "iscrowd": 0,
+            "image_id": 15335,
+            "bbox": [
+                173.66,
+                139.15,
+                208.18,
+                335.46
+            ],
+            "category_id": 1,
+            "id": 1230490
+        },
+        {
+            "area": 5927.082549999999,
+            "iscrowd": 0,
+            "image_id": 15335,
+            "bbox": [
+                237.45,
+                46.43,
+                99.64,
+                107.15
+            ],
+            "category_id": 2,
+            "id": 1248228
+        },
+        {
+            "area": 2162.5128,
+            "iscrowd": 0,
+            "image_id": 15335,
+            "bbox": [
+                599.96,
+                422.9,
+                40.04,
+                57.1
+            ],
+            "category_id": 1,
+            "id": 1879878
+        }
+    ],
+    "categories": [
+        {
+            "supercategory": "person",
+            "id": 1,
+            "name": "person"
+        },
+        {
+            "supercategory": "vehicle",
+            "id": 2,
+            "name": "bicycle"
+        },
+    ]
+}
+
+@pytest.mark.deformable_detr
+@pytest.mark.parametrize("data_format", ["channels_first"])
+@pytest.mark.parametrize("num_channels", [3])
+def test_dataloader(data_format, num_channels):
+    if data_format == "channels_first":
+        input_shape = (1, num_channels, TARGET_HEIGHT, TARGET_WIDTH)
+    else:
+        input_shape = (1, TARGET_HEIGHT, TARGET_WIDTH, num_channels)
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        image_dir = os.path.join(tmpdirname, "images")
+        os.makedirs(image_dir, exist_ok=True)
+
+        # 4 images scenario
+        for row in COCO_DICT['images']:
+            # Load dummy image
+            img_width = row['width']
+            img_height = row['height']
+            filename = row['file_name']
+
+            dummy_image = np.random.randint(low=0, high=255, size=(img_height, img_width, 3), dtype=np.uint8)
+            dummy_image = Image.fromarray(dummy_image)
+
+            # Save dummy image
+            dummy_image.save(os.path.join(image_dir, filename))
+
+        # Store json file
+        with open(os.path.join(tmpdirname, "temp.json"), "w") as f:
+            json.dump(COCO_DICT, f)
+
+        dl = DDETRCOCOLoader(
+            val_json_file=os.path.join(tmpdirname, "temp.json"),
+            shape=input_shape,
+            dtype=np.float32,
+            batch_size=1,
+            data_format="channels_first",
+            image_std=[0.229, 0.224, 0.225],
+            image_dir=image_dir)
+
+        for imgs, _, _, labels in dl:
+            assert imgs[0].shape == input_shape[1:], "Incorrect image dimension"
+            assert labels[0][0].shape[-1] == 7, "Incorrect label format"

--- a/tests/deformable_detr/test_engine.py
+++ b/tests/deformable_detr/test_engine.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""D-DETR Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+
+from nvidia_tao_deploy.utils.decoding import decode_etlt
+from nvidia_tao_deploy.cv.deformable_detr.engine_builder import DDETRDetEngineBuilder
+from nvidia_tao_deploy.cv.deformable_detr.inferencer import DDETRInferencer
+from nvidia_tao_deploy.cv.deformable_detr.utils import post_process
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+NUM_CLASSES = 4
+
+
+@pytest.mark.deformable_detr
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "ddetr/tlt_266_0049_dynamic.etlt")])
+@pytest.mark.parametrize("img_path", [os.path.join(data_path, "L0/temp_astro17.jpg")])
+@pytest.mark.parametrize("model_key", ["nvidia_tao"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+def test_fp_engine(model_path, img_path, model_key, data_type, batch_size):
+    # Engine building part
+    if model_path.endswith("etlt"):
+        tmp_onnx_file, file_format = decode_etlt(model_path, model_key)
+    else:
+        raise ValueError(f"{model_path} has incorrect extension")
+
+    output_engine_path = f"/tmp/deformable_detr.{data_type}.engine"
+
+    builder = DDETRDetEngineBuilder(min_batch_size=1,
+                                    opt_batch_size=2,
+                                    max_batch_size=4,
+                                    )
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(output_engine_path, data_type)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = DDETRInferencer(output_engine_path,
+                                batch_size=batch_size)
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == 3, "Incorrect channel size"
+
+    # Load dummy images
+    dummy_images = []
+    for _ in range(batch_size):
+        dummy_image = Image.open(img_path).resize((w, h))
+        dummy_image = np.asarray(dummy_image, np.float32)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+
+    pred_logits, pred_boxes = trt_infer.infer(dummy_images)
+    assert pred_logits.shape == (batch_size, 300, NUM_CLASSES), "Logit dimension is incorrect"
+    assert pred_boxes.shape == (batch_size, 300, 4), "Bounding box dimension is incorrect"
+
+    # Post-processing
+    target_sizes = np.array([[TARGET_WIDTH, TARGET_HEIGHT, TARGET_WIDTH, TARGET_HEIGHT]])
+    class_labels, scores, boxes = post_process(pred_logits, pred_boxes, target_sizes)
+
+    assert np.min(scores) >= 0, "Scores range is incorrect"
+    assert np.min(class_labels) >= 0 and np.max(class_labels) < NUM_CLASSES, "Class label range is incorrect"

--- a/tests/deformable_detr/test_postprocessing.py
+++ b/tests/deformable_detr/test_postprocessing.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""D-DETR Post-Processing Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+
+from nvidia_tao_deploy.cv.deformable_detr.utils import post_process
+
+
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+NUM_CLASSES = 4
+
+
+@pytest.mark.deformable_detr
+@pytest.mark.parametrize("prediction_shape", [(1, 300, 4), (8, 200, 4)])
+def test_sigmoid(prediction_shape):
+    # Set random probability range
+    pred_logits = np.random.rand(*prediction_shape) * np.random.randint(-10, 10, size=prediction_shape)
+    pred_boxes = np.random.rand(*prediction_shape)
+
+    target_sizes = np.array([[TARGET_WIDTH, TARGET_HEIGHT, TARGET_WIDTH, TARGET_HEIGHT] for _ in range(len(pred_boxes))])
+    class_labels, scores, boxes = post_process(pred_logits, pred_boxes, target_sizes)
+
+    assert np.min(scores) >= 0 and np.max(scores) <= 1, "Scores range is incorrect"
+
+    assert (scores == np.sort(scores, axis=-1)[:, ::-1]).all(), "Score is not sorted in descending order"
+    assert np.min(class_labels) >= 0 and np.max(class_labels) < NUM_CLASSES, "Class label range is incorrect"
+    assert np.min(boxes[..., 0]) >= 0 and np.max(boxes[..., 2]) <= TARGET_WIDTH, "x range is not correct"
+    assert np.min(boxes[..., 1]) >= 0 and np.max(boxes[..., 3]) <= TARGET_WIDTH, "y range is not correct"

--- a/tests/depth_net/__init__.py
+++ b/tests/depth_net/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DepthNet Unit Tests."""

--- a/tests/depth_net/test_engine.py
+++ b/tests/depth_net/test_engine.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DepthNet Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import os
+import tensorrt as trt
+import cv2
+import glob
+import tempfile
+
+from nvidia_tao_deploy.engine.builder import EngineBuilder
+from nvidia_tao_deploy.cv.depth_net.inferencer import DepthNetInferencer
+from nvidia_tao_deploy.cv.depth_net.dataloader import DepthNetDataLoader
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+
+@pytest.fixture(scope="session", params=["fp32"])
+def mono_engine(tmp_path_factory, request):
+    data_type = request.param
+    onnx_file = os.path.join(model_path, "depth_net/deployable_relative_depthanythingv2_large_v1.0.onnx")
+    
+    # Check if model file exists
+    if not os.path.exists(onnx_file):
+        model_dir = os.path.dirname(onnx_file)
+        print(f"\n{'='*80}")
+        print(f"ERROR: Model file not found: {onnx_file}")
+        print(f"{'='*80}")
+        if os.path.exists(model_dir):
+            print(f"\nContents of {model_dir}:")
+            try:
+                contents = os.listdir(model_dir)
+                if contents:
+                    for item in sorted(contents):
+                        item_path = os.path.join(model_dir, item)
+                        if os.path.isdir(item_path):
+                            print(f"  [DIR]  {item}")
+                        else:
+                            size = os.path.getsize(item_path)
+                            print(f"  [FILE] {item} ({size} bytes)")
+                else:
+                    print("  (directory is empty)")
+            except Exception as e:
+                print(f"  Error listing directory: {e}")
+        else:
+            print(f"\nDirectory does not exist: {model_dir}")
+            parent_dir = os.path.dirname(model_dir)
+            if os.path.exists(parent_dir):
+                print(f"\nContents of parent directory {parent_dir}:")
+                try:
+                    for item in sorted(os.listdir(parent_dir)):
+                        print(f"  {item}")
+                except Exception as e:
+                    print(f"  Error listing directory: {e}")
+        print(f"{'='*80}\n")
+    
+    assert onnx_file.endswith("onnx"), f"{onnx_file} has incorrect extension"
+    engines_dir = tmp_path_factory.mktemp("depthnet_engines")
+    engine_path = os.path.join(str(engines_dir), f"nvdepthanythingv2.{data_type}.engine")
+    if not os.path.exists(engine_path):
+        # Build with max_batch_size to cover test param up to 8
+        builder = EngineBuilder(min_batch_size=1, opt_batch_size=4, max_batch_size=8, verbose=True)
+        builder.create_network(onnx_file, "onnx")
+        builder.create_engine(engine_path, data_type)
+    return engine_path
+
+
+@pytest.mark.parametrize("left_dir", [os.path.join(data_path, "depth_net/left/")])
+@pytest.mark.parametrize("target_width", [924])
+@pytest.mark.parametrize("target_height", [518])
+def test_build_engine_mono(mono_engine, left_dir, target_height, target_width):
+    assert os.path.exists(mono_engine), "Engine was not generated"
+
+
+@pytest.mark.parametrize("left_dir", [os.path.join(data_path, "depth_net/left/")])
+@pytest.mark.parametrize("batch_size", [1, 2, 4, 8])
+@pytest.mark.parametrize("target_width", [924])
+@pytest.mark.parametrize("target_height", [518])
+def test_infer_mono(mono_engine, left_dir, batch_size, target_height, target_width):
+    trt_infer = DepthNetInferencer(mono_engine, batch_size=batch_size)
+    c, h, w = trt_infer.input_tensors[0].shape
+    assert h == target_height and w == target_width and c == 3
+
+    left_images = sorted(glob.glob(os.path.join(left_dir, "*.png")))
+    assert len(left_images) > 0, f"No images found in {left_dir}"
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as tf:
+        max_items = min(len(left_images), batch_size)
+        for p in left_images[:max_items]:
+            tf.write(f"{p}\n")
+        data_file = tf.name
+
+    loader = DepthNetDataLoader(
+        data_sources=[{"dataset_name": "RelativeMonoDataset", "data_file": data_file}],
+        shape=(batch_size, c, h, w),
+        dtype=trt.nptype(trt_infer.input_tensors[0].tensor_dtype),
+        preprocessor="DepthNet",
+        evaluation=False,
+    )
+
+    for batch, img_paths, scales in loader.get_batch():
+        pred_depths = trt_infer.infer(batch)
+        assert pred_depths.shape == (batch_size, target_height, target_width)
+
+        for scale, pred_depth, img_path in zip(scales, pred_depths, img_paths):
+            new_h, new_w = h, w
+            orig_h, orig_w = int(scale[0] * new_h), int(scale[1] * new_w)
+            pred_depth = cv2.resize(pred_depth, (orig_w, orig_h), interpolation=cv2.INTER_CUBIC)
+            assert pred_depth.shape == (orig_h, orig_w)
+
+@pytest.mark.skip(reason="Stereo model not available - skipping stereo depth tests until model is provided")
+@pytest.fixture(scope="session", params=["fp32", "fp16"])
+def stereo_engine(tmp_path_factory, request):
+    data_type = request.param
+    onnx_file = os.path.join(model_path, "depth_net/deployable_foundationstereo_small_v1.0.onnx")
+    
+    # Check if model file exists
+    if not os.path.exists(onnx_file):
+        model_dir = os.path.dirname(onnx_file)
+        print(f"\n{'='*80}")
+        print(f"ERROR: Model file not found: {onnx_file}")
+        print(f"{'='*80}")
+        if os.path.exists(model_dir):
+            print(f"\nContents of {model_dir}:")
+            try:
+                contents = os.listdir(model_dir)
+                if contents:
+                    for item in sorted(contents):
+                        item_path = os.path.join(model_dir, item)
+                        if os.path.isdir(item_path):
+                            print(f"  [DIR]  {item}")
+                        else:
+                            size = os.path.getsize(item_path)
+                            print(f"  [FILE] {item} ({size} bytes)")
+                else:
+                    print("  (directory is empty)")
+            except Exception as e:
+                print(f"  Error listing directory: {e}")
+        else:
+            print(f"\nDirectory does not exist: {model_dir}")
+            parent_dir = os.path.dirname(model_dir)
+            if os.path.exists(parent_dir):
+                print(f"\nContents of parent directory {parent_dir}:")
+                try:
+                    for item in sorted(os.listdir(parent_dir)):
+                        print(f"  {item}")
+                except Exception as e:
+                    print(f"  Error listing directory: {e}")
+        print(f"{'='*80}\n")
+    
+    assert onnx_file.endswith("onnx"), f"{onnx_file} has incorrect extension"
+    engines_dir = tmp_path_factory.mktemp("depthnet_engines")
+    engine_path = os.path.join(str(engines_dir), f"foundationstereo.{data_type}.engine")
+    if not os.path.exists(engine_path):
+        builder = EngineBuilder(min_batch_size=1, opt_batch_size=2, max_batch_size=2, verbose=True)
+        builder.create_network(onnx_file, "onnx")
+        builder.create_engine(engine_path, data_type)
+    return engine_path
+
+
+@pytest.mark.skip(reason="Stereo model not available - skipping until deployable_foundationstereo_small_v1.0.onnx is provided")
+@pytest.mark.parametrize("left_dir", [os.path.join(data_path, "depth_net/left/")])
+@pytest.mark.parametrize("right_dir", [os.path.join(data_path, "depth_net/right/")])
+@pytest.mark.parametrize("target_width", [736])
+@pytest.mark.parametrize("target_height", [320])
+def test_build_engine_stereo(stereo_engine, left_dir, right_dir, target_height, target_width):
+    assert os.path.exists(stereo_engine), "Engine was not generated"
+
+
+@pytest.mark.skip(reason="Stereo model not available - skipping until deployable_foundationstereo_small_v1.0.onnx is provided")
+@pytest.mark.parametrize("left_dir", [os.path.join(data_path, "depth_net/left/")])
+@pytest.mark.parametrize("right_dir", [os.path.join(data_path, "depth_net/right/")])
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+@pytest.mark.parametrize("target_width", [736])
+@pytest.mark.parametrize("target_height", [320])
+def test_infer_stereo(stereo_engine, left_dir, right_dir, batch_size, target_height, target_width):
+    trt_infer = DepthNetInferencer(stereo_engine, batch_size=batch_size)
+    c, h, w = trt_infer.input_tensors[0].shape
+    assert h == target_height and w == target_width and c == 3
+
+    left_images = sorted(glob.glob(os.path.join(left_dir, "*.png")))
+    right_images = sorted(glob.glob(os.path.join(right_dir, "*.png")))
+    assert len(left_images) > 0 and len(left_images) == len(right_images), "Stereo image pairs mismatch"
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as tf:
+        max_items = min(len(left_images), batch_size)
+        for l, r in zip(left_images[:max_items], right_images[:max_items]):
+            tf.write(f"{l} {r}\n")
+        data_file = tf.name
+
+    loader = DepthNetDataLoader(
+        data_sources=[{"dataset_name": "GenericDataset", "data_file": data_file}],
+        shape=(batch_size, c, h, w),
+        dtype=trt.nptype(trt_infer.input_tensors[0].tensor_dtype),
+        preprocessor="DepthNet",
+        evaluation=False,
+    )
+
+    for batch, img_paths, scales in loader.get_batch():
+        pred_depths = trt_infer.infer(batch)
+        assert pred_depths.shape == (batch_size, target_height, target_width)
+
+        for scale, pred_depth, img_path in zip(scales, pred_depths, img_paths):
+            new_h, new_w = h, w
+            orig_h, orig_w = int(scale[0] * new_h), int(scale[1] * new_w)
+            pred_depth = cv2.resize(pred_depth, (orig_w, orig_h), interpolation=cv2.INTER_CUBIC)
+            assert pred_depth.shape == (orig_h, orig_w)

--- a/tests/depth_net/test_loader.py
+++ b/tests/depth_net/test_loader.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fast tests for DepthNetDataLoader parsing and batching."""
+
+import os
+import tempfile
+import numpy as np
+import pytest
+
+from nvidia_tao_deploy.cv.depth_net.dataloader import DepthNetDataLoader
+
+
+def _write(tmp, lines):
+    for ln in lines:
+        tmp.write((ln + "\n").encode("utf-8"))
+    tmp.flush()
+
+
+def _touch_images(tmpdir, names):
+    paths = []
+    for n in names:
+        p = os.path.join(tmpdir, n)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        # create tiny png
+        import cv2
+        cv2.imwrite(p, (np.random.rand(8, 8, 3) * 255).astype(np.uint8))
+        paths.append(p)
+    return paths
+
+
+@pytest.mark.parametrize("shape", [(2, 3, 16, 16)])
+def test_loader_mono_no_gt(tmp_path, shape):
+    lefts = _touch_images(tmp_path, ["l/0.png", "l/1.png", "l/2.png"])  # more than batch
+    with tempfile.NamedTemporaryFile() as tf:
+        _write(tf, [lefts[0], lefts[1]])
+        loader = DepthNetDataLoader(
+            data_sources=[{"dataset_name": "RelativeMonoDataset", "data_file": tf.name}],
+            shape=shape,
+            dtype=np.float32,
+            preprocessor="DepthNet",
+            evaluation=False,
+        )
+        it = loader.get_batch()
+        batch, paths, scales = next(it)
+        assert batch.shape == shape
+        assert len(paths) <= shape[0]
+        assert len(scales) == len(paths)
+
+
+@pytest.mark.parametrize("shape", [(2, 3, 16, 16)])
+def test_loader_stereo_no_gt(shape, tmp_path):
+    lefts = _touch_images(tmp_path, ["l/0.png", "l/1.png"])  # equal pairs
+    rights = _touch_images(tmp_path, ["r/0.png", "r/1.png"]) 
+    with tempfile.NamedTemporaryFile() as tf:
+        _write(tf, [f"{l} {r}" for l, r in zip(lefts, rights)])
+        loader = DepthNetDataLoader(
+            data_sources=[{"dataset_name": "GenericDataset", "data_file": tf.name}],
+            shape=shape,
+            dtype=np.float32,
+            preprocessor="DepthNet",
+            evaluation=False,
+        )
+        it = loader.get_batch()
+        batch, paths, scales = next(it)
+        assert isinstance(batch, dict)
+        assert batch["left_image"].shape == shape
+        assert batch["right_image"].shape == shape
+        assert len(paths) == len(scales)
+

--- a/tests/detectnet_v2/__init__.py
+++ b/tests/detectnet_v2/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DetectNetv2 Unit Tests."""

--- a/tests/detectnet_v2/test_dataloader.py
+++ b/tests/detectnet_v2/test_dataloader.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DetectNetv2 Data Loading Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+import tempfile
+
+from nvidia_tao_deploy.cv.detectnet_v2.dataloader import DetectNetKITTILoader
+
+
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+CLASSMAP = {
+    "car": "car",
+    "bicycle": "bicycle",
+    "person": "person",
+    "road_sign": "road_sign"
+}
+
+KITTI_DICT = {
+    "0000": [
+        ["person", 0.00, 0, 0.00, 394.00, 321.00, 470.00, 387.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00],
+        ["car", 0.00, 0, 0.00, 549.00, 103.00, 569.00, 163.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+    ],
+    "0020": [
+        ["road_sign", 0.00, 0, 0.00, 212.00, 126.00, 239.00, 190.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+    ]
+}
+
+
+@pytest.mark.faster_rcnn
+@pytest.mark.parametrize("data_format", ["channels_first"])
+@pytest.mark.parametrize("num_channels", [3]) # TODO: Add grayscale support
+@pytest.mark.parametrize("keep_aspect_ratio", [True, False])
+def test_dataloader(data_format, num_channels, keep_aspect_ratio):
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        image_dir = os.path.join(tmpdirname, "images")
+        label_dir = os.path.join(tmpdirname, "labels")
+        os.makedirs(image_dir, exist_ok=True)
+        os.makedirs(label_dir, exist_ok=True)
+
+        for k, v in KITTI_DICT.items():
+            # Load dummy image
+            img_width = np.random.randint(low=800, high=1000)
+            img_height = np.random.randint(low=500, high=600)
+
+            dummy_image = np.random.randint(low=0, high=255, size=(img_height, img_width, 3), dtype=np.uint8)
+            dummy_image = Image.fromarray(dummy_image)
+
+            # Save dummy image
+            dummy_image.save(os.path.join(image_dir, f"{k}.jpg"))
+
+            # Save dummy label
+            np.savetxt(os.path.join(label_dir, f"{k}.txt"), v, fmt="%s")
+    
+        dl = DetectNetKITTILoader(
+            shape=(num_channels, TARGET_HEIGHT, TARGET_WIDTH),
+            image_dirs=[image_dir],
+            label_dirs=[label_dir],
+            mapping_dict=CLASSMAP,
+            batch_size=1,
+            dtype=np.float32)
+
+        for (imgs, labels) in dl:
+            assert labels.shape[-1] == 6, "Label dim does not match"
+
+            if data_format == "channels_first":
+                b, c, h, w = imgs.shape
+            else:
+                b, h, w, c = imgs.shape
+            
+            assert b == 1, "Batch size does not match"
+            assert c == num_channels, "Height does not match"
+            assert h == TARGET_HEIGHT, "Height does not match"
+            assert w == TARGET_WIDTH, "Height does not match"

--- a/tests/detectnet_v2/test_engine.py
+++ b/tests/detectnet_v2/test_engine.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DetectNetv2 Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+
+from nvidia_tao_deploy.utils import LEGACY_API_MODE
+from nvidia_tao_deploy.utils.decoding import decode_etlt
+from nvidia_tao_deploy.cv.detectnet_v2.engine_builder import DetectNetEngineBuilder
+from nvidia_tao_deploy.cv.detectnet_v2.inferencer import DetectNetInferencer
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+TARGET_CLASSES = {
+    "peoplenet": ["person", "bag", "face"],
+    "dashcamnet": ["car", "bicycle", "person", "road_sign"],
+}
+MODEL_LIST = [
+    os.path.join(model_path, "detectnet_v2/resnet34_peoplenet.etlt")
+]
+if LEGACY_API_MODE():
+    MODEL_LIST.append(os.path.join(model_path, "detectnet_v2/resnet18_dashcamnet_pruned.etlt"))
+
+
+@pytest.mark.detectnet_v2
+@pytest.mark.parametrize(
+    "model_path",
+    MODEL_LIST    
+)
+@pytest.mark.parametrize("img_path", [os.path.join(data_path, "L0/temp_its_mini.jpg")])
+@pytest.mark.parametrize("model_key", ["tlt_encode"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("batch_size", [2])
+def test_fp_engine(model_path, img_path, model_key, data_type, batch_size):
+    # Engine building part
+    target_classes = None
+    for network, class_list in TARGET_CLASSES.items():
+        if network in model_path:
+            target_classes = class_list
+    if model_path.endswith("etlt"):
+        tmp_onnx_file, file_format = decode_etlt(model_path, model_key)
+    else:
+        raise ValueError(f"{model_path} has incorrect extension")
+
+    output_engine_path = f"/tmp/detectnet_v2.{data_type}.engine"
+
+    builder = DetectNetEngineBuilder(min_batch_size=1,
+                                     opt_batch_size=2,
+                                     max_batch_size=4)
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(output_engine_path, data_type)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = DetectNetInferencer(output_engine_path, target_classes=target_classes, batch_size=batch_size)
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == 3, "Incorrect channel size"
+
+    dummy_images = []
+
+    for _ in range(batch_size):
+        # Load dummy image
+        dummy_image = Image.open(img_path).resize((TARGET_WIDTH, TARGET_HEIGHT))
+        dummy_image = np.asarray(dummy_image, np.float32)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+
+    y_pred = trt_infer.infer(dummy_images)
+    assert sorted(y_pred.keys()) == sorted(target_classes), "Output with incorrect keys in the dict"

--- a/tests/efficientdet_tf1/__init__.py
+++ b/tests/efficientdet_tf1/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""EfficientDet TF1 Unit Tests."""

--- a/tests/efficientdet_tf1/test_dataloader.py
+++ b/tests/efficientdet_tf1/test_dataloader.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""EfficientDet Data Loading Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+import json
+from PIL import Image
+import tempfile
+
+from nvidia_tao_deploy.cv.efficientdet_tf1.dataloader import EfficientDetCOCOLoader
+
+
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+COCO_DICT = {
+    "images": [
+        {
+            "license": 1,
+            "file_name": "000000552775.jpg",
+            "coco_url": "http://images.cocodataset.org/val2017/000000552775.jpg",
+            "height": 500,
+            "width": 375,
+            "id": 552775
+        },
+        {
+            "license": 3,
+            "file_name": "000000394940.jpg",
+            "coco_url": "http://images.cocodataset.org/val2017/000000394940.jpg",
+            "height": 640,
+            "width": 426,
+            "id": 394940
+        },
+        {
+            "license": 2,
+            "file_name": "000000015335.jpg",
+            "coco_url": "http://images.cocodataset.org/val2017/000000015335.jpg",
+            "height": 480,
+            "width": 640,            
+            "id": 15335
+        }
+    ],
+    "annotations": [
+        {
+            "area": 475.48160000000036,
+            "iscrowd": 0,
+            "image_id": 552775,
+            "bbox": [
+                286.65,
+                96.17,
+                19.33,
+                27.98
+            ],
+            "category_id": 1,
+            "id": 83208
+        },
+        {
+            "area": 384.27450000000016,
+            "iscrowd": 0,
+            "image_id": 552775,
+            "bbox": [
+                251.46,
+                93.75,
+                19.76,
+                29.02
+            ],
+            "category_id": 2,
+            "id": 93799
+        },
+        {
+            "area": 14986.082449999996,
+            "iscrowd": 0,
+            "image_id": 552775,
+            "bbox": [
+                1.87,
+                133.08,
+                94.02,
+                204.39
+            ],
+            "category_id": 1,
+            "id": 1749992
+        },
+        {
+            "area": 114105.64780000002,
+            "iscrowd": 0,
+            "image_id": 394940,
+            "bbox": [
+                0.0,
+                77.18,
+                425.79,
+                413.66
+            ],
+            "category_id": 1,
+            "id": 2164128
+        },
+        {
+            "area": 56257.02764999998,
+            "iscrowd": 0,
+            "image_id": 15335,
+            "bbox": [
+                365.92,
+                15.07,
+                274.08,
+                458.47
+            ],
+            "category_id": 1,
+            "id": 1216332
+        },
+        {
+            "area": 44578.0246,
+            "iscrowd": 0,
+            "image_id": 15335,
+            "bbox": [
+                173.66,
+                139.15,
+                208.18,
+                335.46
+            ],
+            "category_id": 1,
+            "id": 1230490
+        },
+        {
+            "area": 5927.082549999999,
+            "iscrowd": 0,
+            "image_id": 15335,
+            "bbox": [
+                237.45,
+                46.43,
+                99.64,
+                107.15
+            ],
+            "category_id": 2,
+            "id": 1248228
+        },
+        {
+            "area": 2162.5128,
+            "iscrowd": 0,
+            "image_id": 15335,
+            "bbox": [
+                599.96,
+                422.9,
+                40.04,
+                57.1
+            ],
+            "category_id": 1,
+            "id": 1879878
+        }
+    ],
+    "categories": [
+        {
+            "supercategory": "person",
+            "id": 1,
+            "name": "person"
+        },
+        {
+            "supercategory": "vehicle",
+            "id": 2,
+            "name": "bicycle"
+        },
+    ]
+}
+
+@pytest.mark.efficientdet_tf1
+@pytest.mark.parametrize("data_format", ["channels_last"])
+@pytest.mark.parametrize("num_channels", [3])
+def test_dataloader(data_format, num_channels):
+    if data_format == "channels_first":
+        input_shape = (1, num_channels, TARGET_HEIGHT, TARGET_WIDTH)
+    else:
+        input_shape = (1, TARGET_HEIGHT, TARGET_WIDTH, num_channels)
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        image_dir = os.path.join(tmpdirname, "images")
+        os.makedirs(image_dir, exist_ok=True)
+
+        # 4 images scenario
+        for row in COCO_DICT['images']:
+            # Load dummy image
+            img_width = row['width']
+            img_height = row['height']
+            filename = row['file_name']
+
+            dummy_image = np.random.randint(low=0, high=255, size=(img_height, img_width, 3), dtype=np.uint8)
+            dummy_image = Image.fromarray(dummy_image)
+
+            # Save dummy image
+            dummy_image.save(os.path.join(image_dir, filename))
+
+        # Store json file
+        with open(os.path.join(tmpdirname, "temp.json"), "w") as f:
+            json.dump(COCO_DICT, f)
+
+        dl = EfficientDetCOCOLoader(
+            os.path.join(tmpdirname, "temp.json"),
+            shape=input_shape,
+            dtype=np.float32,
+            batch_size=1,
+            image_dir=image_dir)
+
+        for imgs, _, _, labels in dl:
+            assert imgs[0].shape == input_shape[1:], "Incorrect image dimension"
+            assert labels[0][0].shape[-1] == 7, "Incorrect label format"

--- a/tests/efficientdet_tf1/test_engine.py
+++ b/tests/efficientdet_tf1/test_engine.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""EfficientDet Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+
+from nvidia_tao_deploy.utils.decoding import decode_etlt
+from nvidia_tao_deploy.cv.efficientdet_tf1.engine_builder import EfficientDetEngineBuilder
+from nvidia_tao_deploy.cv.efficientdet_tf1.inferencer import EfficientDetInferencer
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+NUM_CLASSES = 2
+
+
+@pytest.mark.efficientdet_tf1
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "efficientdet_tf1/model.step-39060_trt825.etlt")])
+@pytest.mark.parametrize("img_path", [os.path.join(data_path, "L0/temp_avlp.jpg")])
+@pytest.mark.parametrize("model_key", ["nvidia_tlt"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("max_detections_per_image", [100])
+@pytest.mark.parametrize("batch_size", [1])
+def test_fp_engine(model_path, img_path, model_key, data_type, max_detections_per_image, batch_size):
+    # Engine building part
+    if model_path.endswith("etlt"):
+        tmp_onnx_file, file_format = decode_etlt(model_path, model_key)
+    else:
+        raise ValueError(f"{model_path} has incorrect extension")
+
+    output_engine_path = f"/tmp/efficientdet_tf1.{data_type}.engine"
+
+    builder = EfficientDetEngineBuilder(min_batch_size=1,
+                                        opt_batch_size=2,
+                                        max_batch_size=4)
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(output_engine_path, data_type, tf2=True)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = EfficientDetInferencer(output_engine_path, batch_size=batch_size,
+                                       data_format="channel_last",
+                                       max_detections_per_image=max_detections_per_image)
+
+    # Check engine model shape
+    h, w, c = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == 3, "Incorrect channel size"
+
+    dummy_images = []
+
+    for _ in range(batch_size):
+        # Load dummy image
+        dummy_image = Image.open(img_path).resize((TARGET_WIDTH, TARGET_HEIGHT))
+        dummy_image = np.asarray(dummy_image, np.float32)
+        dummy_images.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+
+    y_pred = trt_infer.infer(dummy_images, scales=[1.0, 1.0])
+
+    pred_keys = ['num_detections', 'detection_classes', 'detection_scores', 'detection_boxes']
+    assert sorted(y_pred.keys()) == sorted(pred_keys), "Prediction does not have correct format"
+    assert y_pred['detection_classes'].shape[-1] == max_detections_per_image, "Number of detection is incorrect"
+    assert y_pred['detection_boxes'].shape[1:] == (max_detections_per_image, 4), "Number of detection is incorrect"

--- a/tests/faster_rcnn/__init__.py
+++ b/tests/faster_rcnn/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""FRCNN Unit Tests."""

--- a/tests/faster_rcnn/test_dataloader.py
+++ b/tests/faster_rcnn/test_dataloader.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Faster RCNN Data Loading Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+import tempfile
+
+from nvidia_tao_deploy.cv.faster_rcnn.dataloader import FRCNNKITTILoader
+
+
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+CLASSMAP = {
+    "car": "car",
+    "bicycle": "bicycle",
+    "person": "person",
+    "road_sign": "road_sign"
+}
+
+KITTI_DICT = {
+    "0000": [
+        ["person", 0.00, 0, 0.00, 394.00, 321.00, 470.00, 387.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00],
+        ["car", 0.00, 0, 0.00, 549.00, 103.00, 569.00, 163.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+    ],
+    "0020": [
+        ["road_sign", 0.00, 0, 0.00, 212.00, 126.00, 239.00, 190.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+    ]
+}
+
+
+@pytest.mark.faster_rcnn
+@pytest.mark.parametrize("data_format", ["channels_first"])
+@pytest.mark.parametrize("num_channels", [1, 3]) # TODO: Add grayscale support
+def test_dataloader(data_format, num_channels):
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        image_dir = os.path.join(tmpdirname, "images")
+        label_dir = os.path.join(tmpdirname, "labels")
+        os.makedirs(image_dir, exist_ok=True)
+        os.makedirs(label_dir, exist_ok=True)
+
+        for k, v in KITTI_DICT.items():
+            # Load dummy image
+            img_width = np.random.randint(low=800, high=1000)
+            img_height = np.random.randint(low=500, high=600)
+
+            dummy_image = np.random.randint(low=0, high=255, size=(img_height, img_width, 3), dtype=np.uint8)
+            dummy_image = Image.fromarray(dummy_image)
+
+            # Save dummy image
+            dummy_image.save(os.path.join(image_dir, f"{k}.jpg"))
+
+            # Save dummy label
+            np.savetxt(os.path.join(label_dir, f"{k}.txt"), v, fmt="%s")
+    
+        dl = FRCNNKITTILoader(
+            shape=(num_channels, TARGET_HEIGHT, TARGET_WIDTH),
+            image_dirs=[image_dir],
+            label_dirs=[label_dir],
+            mapping_dict=CLASSMAP,
+            batch_size=1,
+            dtype=np.float32)
+
+        for (imgs, labels) in dl:
+            assert labels.shape[-1] == 6, "Label dim does not match"
+
+            if data_format == "channels_first":
+                b, c, h, w = imgs.shape
+            else:
+                b, h, w, c = imgs.shape
+            
+            assert b == 1, "Batch size does not match"
+            assert c == num_channels, "Height does not match"
+            assert h == TARGET_HEIGHT, "Height does not match"
+            assert w == TARGET_WIDTH, "Height does not match"

--- a/tests/faster_rcnn/test_engine.py
+++ b/tests/faster_rcnn/test_engine.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Faster RCNN Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+
+from nvidia_tao_deploy.utils.decoding import decode_etlt
+from nvidia_tao_deploy.cv.faster_rcnn.engine_builder import FRCNNEngineBuilder
+from nvidia_tao_deploy.cv.faster_rcnn.inferencer import FRCNNInferencer
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+
+# UFF models no longer supported in DFLW 24.06+
+# os.path.join(model_path, "faster_rcnn/frcnn_kitti_resnet18.epoch24_trt8.etlt"
+@pytest.mark.faster_rcnn
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "faster_rcnn/frcnn_kitti_resnet18_onnx.epoch12.etlt")])
+@pytest.mark.parametrize("img_path", [os.path.join(data_path, "L0/temp_its_mini.jpg")])
+@pytest.mark.parametrize("model_key", ["nvidia_tlt"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("batch_size", [1])
+def test_fp_engine(model_path, img_path, model_key, data_type, batch_size):
+    # Engine building part
+    if model_path.endswith("etlt"):
+        tmp_onnx_file, file_format = decode_etlt(model_path, model_key)
+    else:
+        raise ValueError(f"{model_path} has incorrect extension")
+
+    output_engine_path = f"/tmp/faster_rcnn.{data_type}.engine"
+
+    builder = FRCNNEngineBuilder(min_batch_size=1,
+                                 opt_batch_size=1,
+                                 max_batch_size=1)
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(output_engine_path, data_type)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    input_shape = builder._input_dims["input_image"]
+    trt_infer = FRCNNInferencer(output_engine_path, input_shape=(1,) + input_shape, batch_size=batch_size)
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert c == 3, "Incorrect channel size"
+
+    # Load dummy images
+    dummy_images = []
+    for _ in range(batch_size):
+        dummy_image = Image.open(img_path).resize((w, h))
+        dummy_image = np.asarray(dummy_image, np.float32)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+
+    y_pred = trt_infer.infer(dummy_images)
+    assert y_pred[0].shape[-1] == 6, "Shape of prediction is incorrect"

--- a/tests/grounding_dino/__init__.py
+++ b/tests/grounding_dino/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Grounding DINO Unit Tests."""

--- a/tests/grounding_dino/test_engine.py
+++ b/tests/grounding_dino/test_engine.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Grounding DINO Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+from transformers import AutoTokenizer
+
+from nvidia_tao_deploy.cv.grounding_dino.engine_builder import GDINODetEngineBuilder
+from nvidia_tao_deploy.cv.grounding_dino.inferencer import GDINOInferencer
+from nvidia_tao_deploy.cv.grounding_dino.utils import post_process, tokenize_captions
+
+
+model_dir = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_dir = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+MAX_TEXT_LEN = 256
+
+
+@pytest.mark.deformable_detr
+@pytest.mark.parametrize("model_path", [os.path.join(model_dir, "grounding_dino/swint.onnx")])
+@pytest.mark.parametrize("img_path", [os.path.join(data_dir, "L0/temp_astro17.jpg")])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("batch_size", [1])
+def test_fp_engine(model_path, img_path, data_type, batch_size):
+    # Engine building part
+
+    output_engine_path = f"/tmp/grounding_dino.{data_type}.engine"
+
+    # @seanf note: g-dino only supports a batch size of 1
+    builder = GDINODetEngineBuilder(min_batch_size=1,
+                                    opt_batch_size=1,
+                                    max_batch_size=1)
+    builder.create_network(model_path, "onnx")
+    builder.create_engine(output_engine_path, data_type)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = GDINOInferencer(output_engine_path,
+                                num_classes=MAX_TEXT_LEN,
+                                batch_size=batch_size)
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == 3, "Incorrect channel size"
+
+    # Load dummy image
+    dummy_image = Image.open(img_path).resize((TARGET_WIDTH, TARGET_HEIGHT))
+    dummy_image = np.asarray(dummy_image, np.float32)
+
+    # Add batch dim
+    dummy_image = np.expand_dims(dummy_image, 0)
+    dummy_image = np.transpose(dummy_image, axes=(0, 3, 1, 2))
+
+    cat_list = ["person", "chair"]
+    caption = [" . ".join(cat_list) + ' .'] * batch_size
+
+    tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+    input_ids, attention_mask, position_ids, token_type_ids, text_self_attention_masks, pos_map = tokenize_captions(tokenizer, cat_list, caption, MAX_TEXT_LEN)
+    inputs = (dummy_image, input_ids, attention_mask, position_ids, token_type_ids, text_self_attention_masks)
+
+    pred_logits, pred_boxes = trt_infer.infer(inputs)
+    assert pred_logits.shape[1:] == (900, MAX_TEXT_LEN), "Logit dimension is incorrect"
+    assert pred_boxes.shape[1:] == (900, 4), "Bounding box dimension is incorrect"
+
+    # Post-processing
+    target_sizes = np.array([[TARGET_WIDTH, TARGET_HEIGHT, TARGET_WIDTH, TARGET_HEIGHT]])
+    class_labels, scores, boxes = post_process(pred_logits, pred_boxes, target_sizes, pos_map)
+
+    assert np.min(scores) >= 0, "Scores range is incorrect"
+    assert np.min(class_labels) >= 0 and np.max(class_labels) < MAX_TEXT_LEN, "Class label range is incorrect"

--- a/tests/lprnet/__init__.py
+++ b/tests/lprnet/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""LPRNet Unit Tests."""

--- a/tests/lprnet/test_dataloader.py
+++ b/tests/lprnet/test_dataloader.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""LPRNet Data Loading Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+import random
+import string
+from PIL import Image
+import tempfile
+
+from nvidia_tao_deploy.cv.lprnet.dataloader import LPRNetLoader
+
+
+TARGET_WIDTH = 96
+TARGET_HEIGHT = 48
+classes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
+
+@pytest.mark.lprnet
+@pytest.mark.parametrize("data_format", ["channels_first"])
+@pytest.mark.parametrize("num_channels", [3])
+def test_dataloader(data_format, num_channels):
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        image_dir = os.path.join(tmpdirname, "images")
+        label_dir = os.path.join(tmpdirname, "labels")
+        os.makedirs(image_dir, exist_ok=True)
+        os.makedirs(label_dir, exist_ok=True)
+
+        for i in range(3):
+            # Load dummy image
+            img_width = np.random.randint(low=800, high=1000)
+            img_height = np.random.randint(low=500, high=600)
+            
+            dummy_image = np.random.randint(low=0, high=255, size=(img_height, img_width, 3), dtype=np.uint8)
+            dummy_image = Image.fromarray(dummy_image)
+
+            # Save dummy image
+            dummy_image.save(os.path.join(image_dir, f"{i}.jpg"))
+
+            # Dummy label of length 7
+            label = ''.join(random.choices(string.ascii_letters + string.digits, k=7)).upper()
+            np.savetxt(os.path.join(label_dir, f"{i}.txt"), [label], fmt="%s")
+    
+        dl = LPRNetLoader(
+            (3, TARGET_HEIGHT, TARGET_WIDTH),
+            [image_dir],
+            [label_dir],
+            classes,
+            batch_size=1,
+            dtype=np.float32)
+
+        for (imgs, labels) in dl:
+            assert isinstance(labels[0], str), "Invalid label type"
+            if data_format == "channels_first":
+                b, c, h, w = imgs.shape
+            else:
+                b, h, w, c = imgs.shape
+            
+            assert b == 1, "Batch size does not match"
+            assert c == num_channels, "Height does not match"
+            assert h == TARGET_HEIGHT, "Height does not match"
+            assert w == TARGET_WIDTH, "Height does not match"

--- a/tests/lprnet/test_engine.py
+++ b/tests/lprnet/test_engine.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""LPRNet Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+
+from nvidia_tao_deploy.utils.decoding import decode_etlt
+from nvidia_tao_deploy.cv.lprnet.engine_builder import LPRNetEngineBuilder
+from nvidia_tao_deploy.cv.lprnet.inferencer import LPRNetInferencer
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+TARGET_WIDTH = 96
+TARGET_HEIGHT = 48
+
+
+@pytest.mark.lprnet
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "lprnet/us_lprnet_baseline18_deployable.etlt")])
+@pytest.mark.parametrize("img_path", [os.path.join(data_path, "L0/temp_lpr.jpg")])
+@pytest.mark.parametrize("model_key", ["nvidia_tlt"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("batch_size", [2])
+def test_fp_engine(model_path, img_path, model_key, data_type, batch_size):
+    # Engine building part
+    if model_path.endswith("etlt"):
+        tmp_onnx_file, file_format = decode_etlt(model_path, model_key)
+    else:
+        raise ValueError(f"{model_path} has incorrect extension")
+
+    output_engine_path = f"/tmp/lprnet.{data_type}.engine"
+
+    builder = LPRNetEngineBuilder(min_batch_size=1,
+                                  opt_batch_size=2,
+                                  max_batch_size=4)
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(output_engine_path, data_type)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = LPRNetInferencer(output_engine_path, batch_size=batch_size)
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == 3, "Incorrect channel size"
+
+    # Load dummy image
+    dummy_images = []
+
+    for _ in range(batch_size):
+        dummy_image = Image.open(img_path).resize((TARGET_WIDTH, TARGET_HEIGHT))
+        dummy_image = np.asarray(dummy_image, np.float32)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+
+    y_pred = trt_infer.infer(dummy_images)
+    assert y_pred[0].shape[-1] == 24, "Shape of prediction is incorrect"

--- a/tests/lprnet/test_utils.py
+++ b/tests/lprnet/test_utils.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test lprnet model builder."""
+
+import os
+import pytest
+
+from nvidia_tao_deploy.cv.lprnet.utils import decode_ctc_conf
+
+# Temporarily skipping this test on CI.
+# to be fixed in another MR.
+@pytest.mark.lprnet
+@pytest.mark.skipif(
+    os.getenv("CI_PROJECT_DIR", None) is not None,
+    reason='Skipping running on CI.'
+)
+def test_ctc_decoder():
+    classes = ["a", "b", "c"]
+    blank_id = 3
+
+    pred_id = [[0, 0, 0, 3, 1, 2]]
+    pred_conf = [[0.99, 0.99, 0.99, 0.99, 0.99, 0.99]]
+    expected_lp = "abc"
+    decoded_lp, _ = decode_ctc_conf((pred_id, pred_conf), classes, blank_id)
+
+    assert expected_lp == decoded_lp[0]

--- a/tests/mask_rcnn/__init__.py
+++ b/tests/mask_rcnn/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mask RCNN Unit Tests."""

--- a/tests/mask_rcnn/test_dataloader.py
+++ b/tests/mask_rcnn/test_dataloader.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mask RCNN Data Loading Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+import json
+from PIL import Image
+import tempfile
+
+from nvidia_tao_deploy.cv.mask_rcnn.dataloader import MRCNNCOCOLoader
+
+
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 576
+COCO_DICT = {
+    "images": [
+        {
+            "license": 1,
+            "file_name": "000000552775.jpg",
+            "coco_url": "http://images.cocodataset.org/val2017/000000552775.jpg",
+            "height": 500,
+            "width": 375,
+            "id": 552775
+        },
+        {
+            "license": 3,
+            "file_name": "000000394940.jpg",
+            "coco_url": "http://images.cocodataset.org/val2017/000000394940.jpg",
+            "height": 640,
+            "width": 426,
+            "id": 394940
+        },
+        {
+            "license": 2,
+            "file_name": "000000015335.jpg",
+            "coco_url": "http://images.cocodataset.org/val2017/000000015335.jpg",
+            "height": 480,
+            "width": 640,            
+            "id": 15335
+        }
+    ],
+    "annotations": [
+        {
+            "area": 475.48160000000036,
+            "iscrowd": 0,
+            "image_id": 552775,
+            "bbox": [
+                286.65,
+                96.17,
+                19.33,
+                27.98
+            ],
+            "category_id": 1,
+            "id": 83208
+        },
+        {
+            "area": 384.27450000000016,
+            "iscrowd": 0,
+            "image_id": 552775,
+            "bbox": [
+                251.46,
+                93.75,
+                19.76,
+                29.02
+            ],
+            "category_id": 2,
+            "id": 93799
+        },
+        {
+            "area": 14986.082449999996,
+            "iscrowd": 0,
+            "image_id": 552775,
+            "bbox": [
+                1.87,
+                133.08,
+                94.02,
+                204.39
+            ],
+            "category_id": 1,
+            "id": 1749992
+        },
+        {
+            "area": 114105.64780000002,
+            "iscrowd": 0,
+            "image_id": 394940,
+            "bbox": [
+                0.0,
+                77.18,
+                425.79,
+                413.66
+            ],
+            "category_id": 1,
+            "id": 2164128
+        },
+        {
+            "area": 56257.02764999998,
+            "iscrowd": 0,
+            "image_id": 15335,
+            "bbox": [
+                365.92,
+                15.07,
+                274.08,
+                458.47
+            ],
+            "category_id": 1,
+            "id": 1216332
+        },
+        {
+            "area": 44578.0246,
+            "iscrowd": 0,
+            "image_id": 15335,
+            "bbox": [
+                173.66,
+                139.15,
+                208.18,
+                335.46
+            ],
+            "category_id": 1,
+            "id": 1230490
+        },
+        {
+            "area": 5927.082549999999,
+            "iscrowd": 0,
+            "image_id": 15335,
+            "bbox": [
+                237.45,
+                46.43,
+                99.64,
+                107.15
+            ],
+            "category_id": 2,
+            "id": 1248228
+        },
+        {
+            "area": 2162.5128,
+            "iscrowd": 0,
+            "image_id": 15335,
+            "bbox": [
+                599.96,
+                422.9,
+                40.04,
+                57.1
+            ],
+            "category_id": 1,
+            "id": 1879878
+        }
+    ],
+    "categories": [
+        {
+            "supercategory": "person",
+            "id": 1,
+            "name": "person"
+        },
+        {
+            "supercategory": "vehicle",
+            "id": 2,
+            "name": "bicycle"
+        },
+    ]
+}
+
+@pytest.mark.mask_rcnn
+@pytest.mark.parametrize("data_format", ["channels_first"])
+@pytest.mark.parametrize("num_channels", [3])
+def test_dataloader(data_format, num_channels):
+    if data_format == "channels_first":
+        input_shape = (1, num_channels, TARGET_HEIGHT, TARGET_WIDTH)
+    else:
+        input_shape = (1, TARGET_HEIGHT, TARGET_WIDTH, num_channels)
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        image_dir = os.path.join(tmpdirname, "images")
+        os.makedirs(image_dir, exist_ok=True)
+
+        # 4 images scenario
+        for row in COCO_DICT['images']:
+            # Load dummy image
+            img_width = row['width']
+            img_height = row['height']
+            filename = row['file_name']
+
+            dummy_image = np.random.randint(low=0, high=255, size=(img_height, img_width, 3), dtype=np.uint8)
+            dummy_image = Image.fromarray(dummy_image)
+
+            # Save dummy image
+            dummy_image.save(os.path.join(image_dir, filename))
+
+        # Store json file
+        with open(os.path.join(tmpdirname, "temp.json"), "w") as f:
+            json.dump(COCO_DICT, f)
+
+        dl = MRCNNCOCOLoader(
+            os.path.join(tmpdirname, "temp.json"),
+            shape=input_shape,
+            data_format="channels_first",
+            dtype=np.float32,
+            batch_size=1,
+            image_dir=image_dir)
+
+        for imgs, _, _, labels in dl:
+            assert imgs[0].shape == input_shape[1:], "Incorrect image dimension"
+            assert labels[0][0].shape[-1] == 7, "Incorrect label format"

--- a/tests/mask_rcnn/test_engine.py
+++ b/tests/mask_rcnn/test_engine.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mask RCNN Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+
+from nvidia_tao_deploy.utils.decoding import decode_etlt
+from nvidia_tao_deploy.cv.mask_rcnn.engine_builder import MRCNNEngineBuilder
+from nvidia_tao_deploy.cv.mask_rcnn.inferencer import MRCNNInferencer
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 576
+NUM_CLASSES = 2
+
+
+@pytest.mark.skip(reason="UFF models no longer supported")
+@pytest.mark.mask_rcnn
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "mask_rcnn/model.step-600000.etlt")])
+@pytest.mark.parametrize("img_path", [os.path.join(data_path, "L0/temp_astro17.jpg")])
+@pytest.mark.parametrize("model_key", ["nvidia_tlt"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("max_detections_per_image", [100])
+def test_fp_engine(model_path, img_path, model_key, data_type, max_detections_per_image):
+    # Engine building part
+    if model_path.endswith("etlt"):
+        tmp_onnx_file, file_format = decode_etlt(model_path, model_key)
+    else:
+        raise ValueError(f"{model_path} has incorrect extension")
+
+    output_engine_path = f"/tmp/mask_rcnn.{data_type}.engine"
+
+    builder = MRCNNEngineBuilder()
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(output_engine_path, data_type)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = MRCNNInferencer(output_engine_path,
+                                nms_size=max_detections_per_image,
+                                n_classes=NUM_CLASSES,
+                                mask_size=28)
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == 3, "Incorrect channel size"
+
+    # Load dummy image
+    dummy_image = Image.open(img_path).resize((TARGET_WIDTH, TARGET_HEIGHT))
+    dummy_image = np.asarray(dummy_image, np.float32)
+
+    # Add batch dim
+    dummy_image = np.expand_dims(dummy_image, 0)
+
+    y_pred = trt_infer.infer(dummy_image, scales=[1.0, 1.0])
+
+    pred_keys = ['num_detections', 'detection_classes', 'detection_scores', 'detection_boxes', 'detection_masks']
+    assert sorted(y_pred.keys()) == sorted(pred_keys), "Prediction does not have correct format"
+    assert y_pred['detection_classes'].shape[-1] == max_detections_per_image, "Number of detection is incorrect"
+    assert y_pred['detection_boxes'].shape[1:] == (max_detections_per_image, 4), "Number of detection is incorrect"

--- a/tests/metric_learning_recognition/__init__.py
+++ b/tests/metric_learning_recognition/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Metric Learning Recognition model Unit Tests."""

--- a/tests/metric_learning_recognition/test_dataloader.py
+++ b/tests/metric_learning_recognition/test_dataloader.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Classification Data Loading Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+import tempfile
+
+from nvidia_tao_deploy.cv.ml_recog.dataloader import MLRecogClassificationLoader, MLRecogInferenceLoader
+
+TARGET_WIDTH = 224
+TARGET_HEIGHT = 224
+
+
+@pytest.mark.metric_learning_recognition
+@pytest.mark.parametrize("num_channels", [1, 3])
+def test_classification_dataloader(num_channels):
+    # 4 classes dataset scenario
+    dummy_classes = {"a": 0, "b": 1, "c": 2, "d": 3}
+    batch_size = 1
+    input_shape = (num_channels, TARGET_HEIGHT, TARGET_WIDTH)
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+
+        for cls in dummy_classes.keys():
+            # Create class directory
+            os.makedirs(os.path.join(tmpdirname, cls), exist_ok=True)
+
+            # Load dummy image
+            img_width = np.random.randint(low=200, high=300)
+            img_height = np.random.randint(low=200, high=300)
+
+            dummy_image = np.random.randint(low=0, high=255, size=(img_height, img_width, 3), dtype=np.uint8)
+            dummy_image = Image.fromarray(dummy_image)
+
+            # Save dummy image
+            dummy_image.save(os.path.join(tmpdirname, cls, "0000.jpg"))
+
+        dl = MLRecogClassificationLoader(
+            input_shape,
+            tmpdirname,
+            dummy_classes,
+            batch_size=batch_size,
+            image_mean=None,
+            image_std=None,
+            dtype=np.float32)
+
+        for (imgs, labels), cls in zip(dl, dummy_classes.values()):
+            assert labels[0] == cls, "Label does not match"
+
+            b, c, h, w = imgs.shape
+
+            assert b == batch_size, "Batch size does not match"
+            assert c == num_channels, "Num channels does not match"
+            assert h == TARGET_HEIGHT, "Height does not match"
+            assert w == TARGET_WIDTH, "Width does not match"
+
+
+@pytest.mark.metric_learning_recognition
+@pytest.mark.parametrize("num_channels", [1, 3])
+@pytest.mark.parametrize("input_type", ["classification_folder", "image_folder"])
+def test_inference_dataloader(num_channels, input_type):
+    # 4 classes dataset scenario
+    dummy_classes = {"a": 0, "b": 1, "c": 2, "d": 3}
+    input_shape = (num_channels, TARGET_HEIGHT, TARGET_WIDTH)
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+
+        for cls in dummy_classes.keys():
+
+            # Load dummy image
+            img_width = np.random.randint(low=200, high=300)
+            img_height = np.random.randint(low=200, high=300)
+
+            dummy_image = np.random.randint(low=0, high=255, size=(img_height, img_width, 3), dtype=np.uint8)
+            dummy_image = Image.fromarray(dummy_image)
+
+            # Save dummy image
+            if input_type == "classification_folder":
+                # Create class directory
+                os.makedirs(os.path.join(tmpdirname, cls), exist_ok=True)
+                dummy_image.save(os.path.join(tmpdirname, cls, "0000.jpg"))
+            elif input_type == "image_folder":
+                dummy_image.save(os.path.join(tmpdirname, cls + "_0000.jpg"))
+
+        dl = MLRecogInferenceLoader(
+            input_shape,
+            tmpdirname,
+            input_type,
+            batch_size=1,
+            image_mean=None,
+            image_std=None,
+            dtype=np.float32)
+
+        for imgs in dl:
+
+            b, c, h, w = imgs.shape
+
+            assert b == 1, "Batch size does not match"
+            assert c == num_channels, "Num channels does not match"
+            assert h == TARGET_HEIGHT, "Height does not match"
+            assert w == TARGET_WIDTH, "Width does not match"

--- a/tests/metric_learning_recognition/test_engine.py
+++ b/tests/metric_learning_recognition/test_engine.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Classification Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from nvidia_tao_deploy.cv.ml_recog.engine_builder import MLRecogEngineBuilder
+from nvidia_tao_deploy.cv.ml_recog.inferencer import MLRecogInferencer
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+TARGET_WIDTH = 224
+TARGET_HEIGHT = 224
+OUTPUT_DIM = 256
+
+
+@pytest.mark.metric_learning_recognition
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "metric_learning_recognition/ml_model_epoch=000.onnx")])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+def test_fp_engine(model_path, data_type, batch_size):
+
+    output_engine_path = f"/tmp/mlrecog.{data_type}.engine"
+
+    workspace_size = 1
+    min_batch_size = 1
+    opt_batch_size = 2
+    max_batch_size = 4
+    num_channels = 3
+    input_width = TARGET_WIDTH
+    input_height = TARGET_HEIGHT
+    img_mean = [0.485, 0.456, 0.406]
+    img_std = [0.226, 0.226, 0.226]
+
+    if not os.path.exists(output_engine_path):
+
+        builder = MLRecogEngineBuilder(
+            workspace=workspace_size,
+            min_batch_size=min_batch_size,
+            opt_batch_size=opt_batch_size,
+            max_batch_size=max_batch_size,
+            img_std=img_std,
+            img_mean=img_mean)
+        builder.create_network(model_path, file_format="onnx")
+        builder.create_engine(output_engine_path, data_type)
+
+        assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = MLRecogInferencer(output_engine_path,
+                                  input_shape=(batch_size, num_channels, input_height, input_width),
+                                  batch_size=batch_size)
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == 3, "Incorrect channel size"
+
+    # Load dummy image
+    dummy_images = []
+    for _ in range(batch_size):
+        dummy_image = np.random.randint(low=0, high=255, size=(TARGET_HEIGHT, TARGET_WIDTH, 3), dtype=np.uint8)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+
+    y_pred = trt_infer.get_embeddings_from_batch(dummy_images)
+
+    assert y_pred.shape == (batch_size, OUTPUT_DIM), "Incorrect output dimensions"

--- a/tests/multitask_classification/__init__.py
+++ b/tests/multitask_classification/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Classification TF1 Unit Tests."""

--- a/tests/multitask_classification/test_engine.py
+++ b/tests/multitask_classification/test_engine.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Multitask Classification Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from nvidia_tao_deploy.utils.decoding import decode_etlt
+from nvidia_tao_deploy.cv.multitask_classification.engine_builder import MClassificationEngineBuilder
+from nvidia_tao_deploy.cv.multitask_classification.inferencer import MClassificationInferencer
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+TARGET_WIDTH = 60
+TARGET_HEIGHT = 80
+CLASSMAP = {
+    "tasks": ["base_color", "category", "season"],
+    "class_mapping": {
+        "base_color": {"0": "Black", "1": "Blue", "2": "Brown", "3": "Green", "4": "Grey", "5": "Navy Blue", "6": "Pink", "7": "Purple", "8": "Red", "9": "Silver", "10": "White"},
+        "category": {"0": "Bags", "1": "Bottomwear", "2": "Eyewear", "3": "Fragrance", "4": "Innerwear", "5": "Jewellery", "6": "Sandal", "7": "Shoes", "8": "Topwear", "9": "Watches"},
+        "season": {"0": "Fall", "1": "Spring", "2": "Summer", "3": "Winter"}
+    }
+}
+OUTPUT_SHAPE = (1, 20)
+
+
+@pytest.mark.skip(reason="UFF models no longer supported")
+@pytest.mark.multitask_classification
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "multitask_classification/mcls_export.etlt")])
+@pytest.mark.parametrize("model_key", ["nvidia_tlt"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("data_format", ["channel_first"])
+@pytest.mark.parametrize("batch_size", [2])
+def test_fp_engine(model_path, model_key, data_type, data_format, batch_size):
+    # Engine building part
+    if model_path.endswith("etlt"):
+        tmp_onnx_file, file_format = decode_etlt(model_path, model_key)
+    else:
+        raise ValueError(f"{model_path} has incorrect extension")
+
+    output_engine_path = f"/tmp/multitask_classification.{data_type}.engine"
+
+    builder = MClassificationEngineBuilder(output_tasks=CLASSMAP['tasks'],
+                                           min_batch_size=1,
+                                           opt_batch_size=2,
+                                           max_batch_size=4)
+    builder.create_network(tmp_onnx_file, file_format=file_format)
+    builder.create_engine(output_engine_path, data_type)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = MClassificationInferencer(output_engine_path, batch_size=batch_size)
+
+    # Check engine model shape
+    if data_format == "channel_first":
+        c, h, w = trt_infer.input_tensors[0].shape
+    else:
+        h, w, c = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == 3, "Incorrect channel size"
+
+    # Load dummy image
+    dummy_images = []
+    for _ in range(batch_size):
+        dummy_image = np.random.randint(low=0, high=255, size=(TARGET_HEIGHT, TARGET_WIDTH, 3), dtype=np.uint8)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+
+    y_pred = trt_infer.infer(dummy_images)
+
+    for i, (k, v) in enumerate(CLASSMAP['class_mapping'].items()):
+        assert y_pred[i].shape[-1] == len(v), f"Task {k} has incorrect output dimensions"

--- a/tests/ocdnet/__init__.py
+++ b/tests/ocdnet/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OCDnet unit tests."""

--- a/tests/ocdnet/test_engine.py
+++ b/tests/ocdnet/test_engine.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OCDNet Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+
+from nvidia_tao_deploy.utils.decoding import decode_model
+from nvidia_tao_deploy.cv.ocdnet.engine_builder import OCDNetEngineBuilder
+from nvidia_tao_deploy.cv.ocdnet.inferencer import OCDNetInferencer
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/ocdnet/model"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/L1/uber/ocdnet_data/test_data/test"
+TARGET_WIDTH = 1280
+TARGET_HEIGHT = 736
+
+
+@pytest.mark.ocrnet
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "dcn_resnet18_Uber_finetune_icdar15_best.onnx")])
+@pytest.mark.parametrize("img_path", [os.path.join(data_path, "img/img_1.jpg")])
+@pytest.mark.parametrize("model_key", ["nvidia_tao"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+def test_fp_engine(model_path, img_path, model_key, data_type, batch_size):
+    # Engine building part
+    if model_path.endswith("onnx"):
+        tmp_onnx_file, file_format = decode_model(model_path, model_key)
+    else:
+        raise ValueError(f"{model_path} has incorrect extension")
+
+    output_engine_path = f"/tmp/ocdnet.{data_type}.engine"
+
+    builder = OCDNetEngineBuilder(width=TARGET_WIDTH,
+                                  height=TARGET_HEIGHT,
+                                  min_batch_size=1,
+                                  opt_batch_size=2,
+                                  max_batch_size=4)
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(output_engine_path, data_type)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = OCDNetInferencer(engine_path=output_engine_path,
+                                 batch_size=batch_size)
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == 3, "Incorrect channel size"
+
+    # Load dummy image
+    dummy_images = []
+
+    for _ in range(batch_size):
+        dummy_image = Image.open(img_path).resize((TARGET_WIDTH, TARGET_HEIGHT))
+        dummy_image = np.asarray(dummy_image, np.float32)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+
+    results = trt_infer.infer(dummy_images)
+
+    assert results.shape == (batch_size, 1, TARGET_HEIGHT, TARGET_WIDTH)

--- a/tests/ocdnet/test_ocdnet.py
+++ b/tests/ocdnet/test_ocdnet.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import pytest
+import shutil
+import subprocess
+import sys
+
+@pytest.fixture
+def _test_dir():
+#    os.system('tar -xf /home/scratch.metropolis2/tao_ci/tao_deploy/data/L1/uber/ocdnet_data.tar.xz --directory tests/ocdnet/')
+#    tmp_top_dir = "tests/ocdnet/ocdnet_data/"
+    tmp_top_dir = "tests/ocdnet/"
+    yield tmp_top_dir
+
+class TestOCDNet():
+
+    @pytest.mark.skip(reason="OCDNet INT8 calibration issues - skipping until TensorRT engine generation is fixed")
+    @pytest.mark.ocdnet
+    def test_ocdnet_generate_engine(self, tmpdir, _test_dir):
+        """ Tests generation for tensorrt engine.
+        Args:
+            tmpdir: fixture providing a temporary directory unique to the test invocation.
+        """
+        print("tmpdir is {}".format(tmpdir))
+        
+        # Check model files and calibration directory
+        model_dcn18 = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/ocdnet/model/dcn_resnet18_Uber_finetune_icdar15_best.onnx"
+        cal_image_dir = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/L1/uber/ocdnet_data/test_data/train/img"
+        
+        # Check DCN18 model
+        if not os.path.exists(model_dcn18):
+            model_dir = os.path.dirname(model_dcn18)
+            print(f"\n{'='*80}")
+            print(f"ERROR: Model file not found: {model_dcn18}")
+            print(f"{'='*80}")
+            if os.path.exists(model_dir):
+                print(f"\nContents of {model_dir}:")
+                try:
+                    for item in sorted(os.listdir(model_dir)):
+                        item_path = os.path.join(model_dir, item)
+                        if os.path.isdir(item_path):
+                            print(f"  [DIR]  {item}")
+                        else:
+                            size = os.path.getsize(item_path)
+                            print(f"  [FILE] {item} ({size} bytes)")
+                except Exception as e:
+                    print(f"  Error: {e}")
+            else:
+                print(f"\nDirectory does not exist: {model_dir}")
+            print(f"{'='*80}\n")
+        
+        # Check calibration directory
+        if not os.path.exists(cal_image_dir):
+            print(f"\n{'='*80}")
+            print(f"ERROR: Calibration directory not found: {cal_image_dir}")
+            print(f"{'='*80}")
+            parent_dir = os.path.dirname(cal_image_dir)
+            if os.path.exists(parent_dir):
+                print(f"\nContents of parent directory {parent_dir}:")
+                try:
+                    for item in sorted(os.listdir(parent_dir)):
+                        print(f"  {item}")
+                except Exception as e:
+                    print(f"  Error: {e}")
+            print(f"{'='*80}\n")
+        else:
+            # Check number of calibration images
+            try:
+                image_files = [f for f in os.listdir(cal_image_dir) if f.endswith(('.jpg', '.png', '.jpeg'))]
+                required_images = 8 * 2  # batch_size * batches
+                print(f"\nCalibration images: found {len(image_files)}, required {required_images}")
+                if len(image_files) < required_images:
+                    print(f"WARNING: Insufficient calibration images!")
+                    print(f"First 10 files in {cal_image_dir}:")
+                    for f in sorted(image_files)[:10]:
+                        print(f"  {f}")
+            except Exception as e:
+                print(f"Error checking calibration images: {e}")
+        
+        # Create system call.
+        call = (
+            "python3 nvidia_tao_deploy/cv/ocdnet/scripts/gen_trt_engine.py "
+            f" gen_trt_engine.onnx_file={model_dcn18} "
+            f" gen_trt_engine.width=1280 "
+            f" gen_trt_engine.height=736 "
+            f" gen_trt_engine.tensorrt.data_type=int8 "
+            f" gen_trt_engine.tensorrt.calibration.cal_cache_file=tests/ocdnet/out/cal_dcn18.bin "
+            f" gen_trt_engine.tensorrt.calibration.cal_image_dir=[/home/scratch.metropolis2/tao_ci/tao_deploy/data/L1/uber/ocdnet_data/test_data/train/img] "
+            f" gen_trt_engine.tensorrt.calibration.cal_batch_size=8 "
+            f" gen_trt_engine.tensorrt.calibration.cal_batches=2 "
+            f" gen_trt_engine.trt_engine=tests/ocdnet/out/output_dcn18.engine "
+        )
+        # Run the call as subprocess.
+        subprocess.check_call(call, shell=True, stdout=sys.stdout, stderr=sys.stdout)
+
+        # Check whether model is present and encrypted.
+        assert os.path.exists(f"tests/ocdnet/out/output_dcn18.engine")
+        assert os.path.exists(f"tests/ocdnet/out/cal_dcn18.bin")
+
+        # Check DCN50 model
+        model_dcn50 = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/ocdnet/model/dcn_resnet50.onnx"
+        if not os.path.exists(model_dcn50):
+            model_dir = os.path.dirname(model_dcn50)
+            print(f"\n{'='*80}")
+            print(f"ERROR: Model file not found: {model_dcn50}")
+            print(f"{'='*80}")
+            if os.path.exists(model_dir):
+                print(f"\nContents of {model_dir}:")
+                try:
+                    for item in sorted(os.listdir(model_dir)):
+                        item_path = os.path.join(model_dir, item)
+                        if os.path.isdir(item_path):
+                            print(f"  [DIR]  {item}")
+                        else:
+                            size = os.path.getsize(item_path)
+                            print(f"  [FILE] {item} ({size} bytes)")
+                except Exception as e:
+                    print(f"  Error: {e}")
+            print(f"{'='*80}\n")
+        
+        # Create system call.
+        call = (
+            "python3 nvidia_tao_deploy/cv/ocdnet/scripts/gen_trt_engine.py "
+            f" gen_trt_engine.onnx_file={model_dcn50} "
+            f" gen_trt_engine.width=1280 "
+            f" gen_trt_engine.height=736 "
+            f" gen_trt_engine.tensorrt.data_type=int8 "
+            f" gen_trt_engine.tensorrt.calibration.cal_cache_file=tests/ocdnet/out/cal_dcn50.bin "
+            f" gen_trt_engine.tensorrt.calibration.cal_image_dir=[/home/scratch.metropolis2/tao_ci/tao_deploy/data/L1/uber/ocdnet_data/test_data/train/img] "
+            f" gen_trt_engine.tensorrt.calibration.cal_batch_size=8 "
+            f" gen_trt_engine.tensorrt.calibration.cal_batches=2 "
+            f" gen_trt_engine.trt_engine=tests/ocdnet/out/output_dcn50.engine "
+        )
+        # Run the call as subprocess.
+        subprocess.check_call(call, shell=True, stdout=sys.stdout, stderr=sys.stdout)
+
+        # Check whether model is present and encrypted.
+        assert os.path.exists(f"tests/ocdnet/out/output_dcn50.engine")
+        assert os.path.exists(f"tests/ocdnet/out/cal_dcn50.bin")
+
+    @pytest.mark.skip(reason="Depends on test_ocdnet_generate_engine which is skipped")
+    @pytest.mark.ocdnet
+    def test_ocdnet_evaluate(self, tmpdir, _test_dir):
+        """ Tests evaluate on.
+        Args:
+            tmpdir: fixture providing a temporary directory unique to the test invocation.
+        """
+        # Create system call.
+        call = (
+            "python3 nvidia_tao_deploy/cv/ocdnet/scripts/evaluate.py "
+            f" evaluate.trt_engine=tests/ocdnet/out/output_dcn18.engine "
+            f" dataset.validate_dataset.data_path=['/home/scratch.metropolis2/tao_ci/tao_deploy/data/L1/uber/ocdnet_data/test_data/test'] "
+        )
+        # Run the call as subprocess.
+        subprocess.check_call(call, shell=True, stdout=sys.stdout, stderr=sys.stdout)
+
+        # Create system call.
+        call = (
+            "python3 nvidia_tao_deploy/cv/ocdnet/scripts/evaluate.py "
+            f" evaluate.trt_engine=tests/ocdnet/out/output_dcn50.engine "
+            f" dataset.validate_dataset.data_path=['/home/scratch.metropolis2/tao_ci/tao_deploy/data/L1/uber/ocdnet_data/test_data/test'] "
+        )
+        # Run the call as subprocess.
+        subprocess.check_call(call, shell=True, stdout=sys.stdout, stderr=sys.stdout)
+
+    @pytest.mark.skip(reason="Depends on test_ocdnet_generate_engine which is skipped")
+    @pytest.mark.ocdnet
+    def test_ocdnet_inference(self, tmpdir, _test_dir):
+        """ Tests inference on.
+        Args:
+            tmpdir: fixture providing a temporary directory unique to the test invocation.
+        """
+        # Create system call.
+        call = (
+            "python3 nvidia_tao_deploy/cv/ocdnet/scripts/inference.py "
+            f" inference.trt_engine=tests/ocdnet/out/output_dcn18.engine "
+            f" inference.input_folder=/home/scratch.metropolis2/tao_ci/tao_deploy/data/L1/uber/ocdnet_data/test_data/test_part/img "
+            f" inference.results_dir=tests/ocdnet/out/result_ocdnet_inference_dcn18 "
+        )
+        # Run the call as subprocess.
+        subprocess.check_call(call, shell=True, stdout=sys.stdout, stderr=sys.stdout)
+
+        # Check whether infernce result is present.
+        assert os.path.exists(f"tests/ocdnet/out/result_ocdnet_inference_dcn18/img_1_result.jpg")
+        assert os.path.exists(f"tests/ocdnet/out/result_ocdnet_inference_dcn18/img_1.txt")
+        assert os.path.getsize(f"tests/ocdnet/out/result_ocdnet_inference_dcn18/img_1.txt") > 0
+        
+        # Create system call.
+        call = (
+            "python3 nvidia_tao_deploy/cv/ocdnet/scripts/inference.py "
+            f" inference.trt_engine=tests/ocdnet/out/output_dcn50.engine "
+            f" inference.input_folder=/home/scratch.metropolis2/tao_ci/tao_deploy/data/L1/uber/ocdnet_data/test_data/test_part/img "
+            f" inference.results_dir=tests/ocdnet/out/result_ocdnet_inference_dcn50 "
+        )
+        # Run the call as subprocess.
+        subprocess.check_call(call, shell=True, stdout=sys.stdout, stderr=sys.stdout)
+
+        # Check whether infernce result is present.
+        assert os.path.exists(f"tests/ocdnet/out/result_ocdnet_inference_dcn50/img_1_result.jpg")
+        assert os.path.exists(f"tests/ocdnet/out/result_ocdnet_inference_dcn50/img_1.txt")
+        assert os.path.getsize(f"tests/ocdnet/out/result_ocdnet_inference_dcn50/img_1.txt") > 0
+
+        # Delete temp output files
+        shutil.rmtree(f"tests/ocdnet/out")

--- a/tests/ocrnet/__init__.py
+++ b/tests/ocrnet/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OCRNet Unit Tests."""

--- a/tests/ocrnet/test_dataloader.py
+++ b/tests/ocrnet/test_dataloader.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OCRNet Data Loading Unit Tests."""
+
+import pytest
+
+from nvidia_tao_deploy.cv.ocrnet.dataloader import OCRNetLoader
+
+DEFAULT_HEIGHT = 32
+DEFAULT_WIDTH = 100
+DEFAULT_IMG_DIR = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/L0/img/"
+DEFAULT_GT_TXT = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/L0/gt.txt"
+
+@pytest.mark.ocrnet
+@pytest.mark.parametrize("shape", [[1, DEFAULT_HEIGHT, DEFAULT_WIDTH]])
+@pytest.mark.parametrize("image_dirs", [[DEFAULT_IMG_DIR]])
+@pytest.mark.parametrize("label_txts", [[DEFAULT_GT_TXT]])
+@pytest.mark.parametrize("batch_size", [1])
+def test_dataloader(shape, image_dirs, label_txts, batch_size):
+    dl = OCRNetLoader(shape=shape,
+                      image_dirs = image_dirs,
+                      batch_size=batch_size,
+                      label_txts=label_txts)
+    for imgs, labels in dl:
+        assert imgs.shape == (batch_size, DEFAULT_HEIGHT, DEFAULT_WIDTH)
+        assert len(labels) == 1
+        assert labels[0] == "stand"

--- a/tests/ocrnet/test_engine.py
+++ b/tests/ocrnet/test_engine.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OCRNet Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+
+from nvidia_tao_deploy.utils.decoding import decode_etlt
+from nvidia_tao_deploy.cv.ocrnet.engine_builder import OCRNetEngineBuilder
+from nvidia_tao_deploy.cv.ocrnet.inferencer import OCRNetInferencer
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/ocrnet"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/L0/img/"
+TARGET_WIDTH = 100
+TARGET_HEIGHT = 32
+TARGET_SEQ = 26
+ATTN_TARGET_WIDTH = 200
+ATTN_TARGET_HEIGHT = 64
+
+
+@pytest.mark.ocrnet
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "best_accuracy.etlt")])
+@pytest.mark.parametrize("img_path", [os.path.join(data_path, "word_888.png")])
+@pytest.mark.parametrize("model_key", ["nvidia_tao"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+def test_fp_engine(model_path, img_path, model_key, data_type, batch_size):
+    # Engine building part
+    if model_path.endswith("etlt"):
+        tmp_onnx_file, file_format = decode_etlt(model_path, model_key)
+    else:
+        raise ValueError(f"{model_path} has incorrect extension")
+
+    output_engine_path = f"/tmp/ocrnet.{data_type}.engine"
+
+    builder = OCRNetEngineBuilder(min_batch_size=1,
+                                  opt_batch_size=2,
+                                  max_batch_size=4)
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(output_engine_path, data_type)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = OCRNetInferencer(engine_path=output_engine_path,
+                                 batch_size=batch_size)
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == 1, "Incorrect channel size"
+
+    # Load dummy image
+    dummy_images = []
+
+    for _ in range(batch_size):
+        dummy_image = Image.open(img_path).convert("L").resize((TARGET_WIDTH, TARGET_HEIGHT))
+        dummy_image = np.asarray(dummy_image, np.float32)[np.newaxis, :, :]
+        dummy_images.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+
+    output_ids, output_probs = trt_infer.infer(dummy_images)
+
+    assert output_ids.shape == (batch_size, TARGET_SEQ)
+    assert output_probs.shape == (batch_size, TARGET_SEQ)

--- a/tests/optical_inspection/__init__.py
+++ b/tests/optical_inspection/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Optical Inspection unit tests."""

--- a/tests/optical_inspection/test_engine.py
+++ b/tests/optical_inspection/test_engine.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OCRNet Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+
+import numpy as np
+from nvidia_tao_deploy.engine.builder import EngineBuilder
+import tensorrt as trt
+
+from nvidia_tao_deploy.utils.decoding import decode_etlt
+from nvidia_tao_deploy.cv.optical_inspection.inferencer import OpticalInspectionInferencer
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/optical_inspection"
+TARGET_WIDTH = 100
+TARGET_HEIGHT = 400
+OUTPUT_SHAPE = (5,)
+
+
+def load_engine(engine_path):
+    """Check load engine.
+
+    Args:
+        engine_path(str): Path to the engine.
+
+    Return:
+        engine: Return TRT engine.
+    """
+    trt_logger = trt.Logger(trt.Logger.WARNING)
+    trt_runtime = trt.Runtime(trt_logger)
+    trt.init_libnvinfer_plugins(trt_logger, namespace="")
+    with open(engine_path, 'rb') as f:
+        engine_data = f.read()
+    engine = trt_runtime.deserialize_cuda_engine(engine_data)
+    return engine
+
+
+@pytest.mark.optical_inpspection
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "oi_model.onnx")])
+@pytest.mark.parametrize("model_key", ["nvidia_tao"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("batch_size", [1])
+def test_fp_engine(model_path, model_key, data_type, batch_size):
+    # Engine building part
+    if model_path.endswith("etlt"):
+        tmp_onnx_file, file_format = decode_etlt(model_path, model_key)
+    else:
+        tmp_onnx_file = model_path
+        file_format = "onnx"
+
+    output_engine_path = f"/tmp/ocrnet.{data_type}.engine"
+
+    builder = EngineBuilder(min_batch_size=1,
+                            opt_batch_size=1,
+                            max_batch_size=1)
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(output_engine_path, data_type)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    trt_infer = OpticalInspectionInferencer(engine_path=output_engine_path,
+                                            batch_size=batch_size)
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == 3, "Incorrect channel size"
+
+    # Load dummy image
+    dummy_images = []
+    dummy_images1 = []
+    for _ in range(batch_size):
+        dummy_image = np.random.randint(low=0, high=255, size=(TARGET_HEIGHT, TARGET_WIDTH, 3), dtype=np.uint8)
+        dummy_image = np.asarray(dummy_image, np.float32)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+        dummy_images1.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+    dummy_images1 = np.stack(dummy_images1, axis=0)
+
+    results = trt_infer.infer([dummy_images, dummy_images1])
+    assert results[0].shape == (batch_size,) + OUTPUT_SHAPE, "Incorrect output shape"
+    assert results[1].shape == (batch_size,) + OUTPUT_SHAPE, "Incorrect output shape"
+
+    engine = load_engine(output_engine_path)
+    assert type(engine) == trt.tensorrt.ICudaEngine, (
+        "CUDA engine type failed."
+    )
+    del engine

--- a/tests/retinanet/__init__.py
+++ b/tests/retinanet/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""RetinaNet Unit Tests."""

--- a/tests/retinanet/test_dataloader.py
+++ b/tests/retinanet/test_dataloader.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Retinanet Data Loading Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+import tempfile
+
+from nvidia_tao_deploy.cv.retinanet.dataloader import RetinaNetKITTILoader
+
+
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+CLASSMAP = {
+    "car": "car",
+    "bicycle": "bicycle",
+    "person": "person",
+    "road_sign": "road_sign"
+}
+
+KITTI_DICT = {
+    "0000": [
+        ["person", 0.00, 0, 0.00, 394.00, 321.00, 470.00, 387.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00],
+        ["car", 0.00, 0, 0.00, 549.00, 103.00, 569.00, 163.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+    ],
+    "0020": [
+        ["road_sign", 0.00, 0, 0.00, 212.00, 126.00, 239.00, 190.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+    ]
+}
+
+
+@pytest.mark.faster_rcnn
+@pytest.mark.parametrize("data_format", ["channels_first"])
+@pytest.mark.parametrize("num_channels", [1, 3]) # TODO: Add grayscale support
+@pytest.mark.parametrize("keep_aspect_ratio", [True, False])
+def test_dataloader(data_format, num_channels, keep_aspect_ratio):
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        image_dir = os.path.join(tmpdirname, "images")
+        label_dir = os.path.join(tmpdirname, "labels")
+        os.makedirs(image_dir, exist_ok=True)
+        os.makedirs(label_dir, exist_ok=True)
+
+        for k, v in KITTI_DICT.items():
+            # Load dummy image
+            img_width = np.random.randint(low=800, high=1000)
+            img_height = np.random.randint(low=500, high=600)
+
+            dummy_image = np.random.randint(low=0, high=255, size=(img_height, img_width, 3), dtype=np.uint8)
+            dummy_image = Image.fromarray(dummy_image)
+
+            # Save dummy image
+            dummy_image.save(os.path.join(image_dir, f"{k}.jpg"))
+
+            # Save dummy label
+            np.savetxt(os.path.join(label_dir, f"{k}.txt"), v, fmt="%s")
+    
+        dl = RetinaNetKITTILoader(
+            shape=(num_channels, TARGET_HEIGHT, TARGET_WIDTH),
+            image_dirs=[image_dir],
+            label_dirs=[label_dir],
+            mapping_dict=CLASSMAP,
+            batch_size=1,
+            keep_aspect_ratio=keep_aspect_ratio,
+            dtype=np.float32)
+
+        for (imgs, labels) in dl:
+            assert labels.shape[-1] == 6, "Label dim does not match"
+
+            if data_format == "channels_first":
+                b, c, h, w = imgs.shape
+            else:
+                b, h, w, c = imgs.shape
+            
+            assert b == 1, "Batch size does not match"
+            assert c == num_channels, "Height does not match"
+            assert h == TARGET_HEIGHT, "Height does not match"
+            assert w == TARGET_WIDTH, "Height does not match"

--- a/tests/retinanet/test_engine.py
+++ b/tests/retinanet/test_engine.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""RetinaNet Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+
+from nvidia_tao_deploy.utils.decoding import decode_etlt
+from nvidia_tao_deploy.cv.retinanet.engine_builder import RetinaNetEngineBuilder
+from nvidia_tao_deploy.cv.retinanet.inferencer import RetinaNetInferencer
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+
+# UFF no longer supported in DLFw 24.06+
+# os.path.join(model_path, "retinanet/retinanet_resnet18_epoch_080_its_trt825.etlt"
+@pytest.mark.retinanet
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "retinanet/retinanet_resnet18_epoch_015_kitti_onnx.etlt")])
+@pytest.mark.parametrize("img_path", [os.path.join(data_path, "L0/temp_its_mini.jpg")])
+@pytest.mark.parametrize("model_key", ["nvidia_tlt"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+def test_fp_engine(model_path, img_path, model_key, data_type, batch_size):
+    # Engine building part
+    if model_path.endswith("etlt"):
+        tmp_onnx_file, file_format = decode_etlt(model_path, model_key)
+    else:
+        raise ValueError(f"{model_path} has incorrect extension")
+
+    output_engine_path = f"/tmp/retinanet.{data_type}.engine"
+
+    builder = RetinaNetEngineBuilder(min_batch_size=1,
+                                     opt_batch_size=2,
+                                     max_batch_size=4)
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(output_engine_path, data_type)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = RetinaNetInferencer(output_engine_path, data_format="channel_first", batch_size=batch_size)
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert c == 3, "Incorrect channel size"
+
+    dummy_images = []
+
+    # Load dummy image
+    for _ in range(batch_size):
+        dummy_image = Image.open(img_path).resize((w, h))
+        dummy_image = np.asarray(dummy_image, np.float32)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+
+    y_pred = trt_infer.infer(dummy_images)
+    assert y_pred.shape[-1] == 6, "Shape of prediction is incorrect"

--- a/tests/rtdetr/__init__.py
+++ b/tests/rtdetr/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/rtdetr/test_engine.py
+++ b/tests/rtdetr/test_engine.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""RT-DETR Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+
+from nvidia_tao_deploy.utils.decoding import decode_etlt
+from nvidia_tao_deploy.cv.deformable_detr.engine_builder import DDETRDetEngineBuilder
+from nvidia_tao_deploy.cv.deformable_detr.inferencer import DDETRInferencer
+from nvidia_tao_deploy.cv.deformable_detr.utils import post_process
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+NUM_CLASSES = 5
+
+
+@pytest.mark.rtdetr
+@pytest.mark.parametrize(
+    "model_path",
+    [
+        os.path.join(model_path, "rtdetr/its_rtdetr_model_960x544.onnx")
+    ]
+)
+@pytest.mark.parametrize("img_path", [os.path.join(data_path, "L0/temp_astro17.jpg")])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+def test_fp_engine(model_path, img_path, data_type, batch_size):
+    # Engine building part
+    tmp_onnx_file = model_path
+    file_format = os.path.splitext(model_path)[-1].strip(".")
+
+    output_engine_path = f"/tmp/rtdetr.{data_type}.engine"
+
+    builder = DDETRDetEngineBuilder(min_batch_size=1,
+                                    opt_batch_size=2,
+                                    max_batch_size=4,
+                                    workspace=10,  # Setting a max of 10GB.
+                                    )
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(output_engine_path, data_type)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = DDETRInferencer(output_engine_path,
+                                batch_size=batch_size)
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == 3, "Incorrect channel size"
+
+    # Load dummy images
+    dummy_images = []
+    for _ in range(batch_size):
+        dummy_image = Image.open(img_path).resize((w, h))
+        dummy_image = np.asarray(dummy_image, np.float32)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+
+    pred_logits, pred_boxes = trt_infer.infer(dummy_images)
+    assert pred_logits.shape == (batch_size, 300, NUM_CLASSES), "Logit dimension is incorrect"
+    assert pred_boxes.shape == (batch_size, 300, 4), "Bounding box dimension is incorrect"
+
+    # Post-processing
+    target_sizes = np.array([[TARGET_WIDTH, TARGET_HEIGHT, TARGET_WIDTH, TARGET_HEIGHT]])
+    class_labels, scores, boxes = post_process(pred_logits, pred_boxes, target_sizes)
+
+    assert np.min(scores) >= 0, "Scores range is incorrect"
+    assert np.min(class_labels) >= 0 and np.max(class_labels) < NUM_CLASSES, "Class label range is incorrect"

--- a/tests/segformer/__init__.py
+++ b/tests/segformer/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Segformer Unit Tests."""

--- a/tests/segformer/test_dataloader.py
+++ b/tests/segformer/test_dataloader.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Segformer Data Loading Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+import tempfile
+
+from nvidia_tao_deploy.cv.segformer.dataloader import SegformerLoader
+
+
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+NUM_CLASSES = 2
+
+
+@pytest.mark.faster_rcnn
+@pytest.mark.parametrize("data_format", ["channels_first"])
+@pytest.mark.parametrize("num_channels", [3])  # Grayscale is also channel size 3
+@pytest.mark.parametrize("resize_method", ["bilinear", "BICUBIC"])
+@pytest.mark.parametrize("input_image_type", ["color", "grayscale"])
+@pytest.mark.parametrize("keep_ratio", [True, False])
+def test_dataloader(data_format, num_channels, input_image_type, resize_method, keep_ratio):
+    if data_format == "channels_first":
+        input_shape = (num_channels, TARGET_HEIGHT, TARGET_WIDTH)
+    else:
+        input_shape = (TARGET_HEIGHT, TARGET_WIDTH, num_channels)
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        image_dir = os.path.join(tmpdirname, "images")
+        label_dir = os.path.join(tmpdirname, "labels")
+        os.makedirs(image_dir, exist_ok=True)
+        os.makedirs(label_dir, exist_ok=True)
+
+        for i in range(3):
+            # Load dummy image
+            img_width = np.random.randint(low=800, high=1000)
+            img_height = np.random.randint(low=500, high=600)
+            
+            dummy_image = np.random.randint(low=0, high=255, size=(img_height, img_width, 3), dtype=np.uint8)
+            dummy_image = Image.fromarray(dummy_image)
+
+            # Save dummy image
+            dummy_image.save(os.path.join(image_dir, f"{i}.jpg"))
+
+            # Dummy mask label with near-center being 1
+            dummy_mask = np.zeros((img_height, img_width))
+            dummy_mask[262:282, 470:490] = 1
+            dummy_mask = Image.fromarray((dummy_mask * 255).astype(np.uint8))
+
+            # Save dummy mask
+            dummy_mask.save(os.path.join(label_dir, f"{i}.png"))
+
+        dl = SegformerLoader(
+            shape=input_shape,
+            image_data_source=[image_dir],
+            label_data_source=[label_dir],
+            num_classes=NUM_CLASSES,
+            batch_size=1,
+            resize_method=resize_method,
+            input_image_type=input_image_type,
+            keep_ratio=keep_ratio,
+            image_mean=[123.675, 116.28, 103.53],
+            image_std=[58.395, 57.12, 57.375],
+            dtype=np.float32)
+
+        for (imgs, labels) in dl:
+            if data_format == "channels_first":
+                b, c, h, w = imgs.shape
+            else:
+                b, h, w, c = imgs.shape
+
+            assert b == 1, "Batch size does not match"
+            assert c == num_channels, "Height does not match"
+            assert h == TARGET_HEIGHT, "Height does not match"
+            assert w == TARGET_WIDTH, "Height does not match"
+
+            assert labels.shape[1:] == (TARGET_HEIGHT, TARGET_WIDTH), "Label dim does not match"

--- a/tests/segformer/test_engine.py
+++ b/tests/segformer/test_engine.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Segformer Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+import cv2
+from PIL import Image
+
+from nvidia_tao_deploy.utils.decoding import decode_model
+from nvidia_tao_deploy.cv.segformer.engine_builder import SegformerEngineBuilder
+from nvidia_tao_deploy.cv.segformer.inferencer import SegformerInferencer
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+TARGET_WIDTH = 512
+TARGET_HEIGHT = 512
+
+
+@pytest.mark.unet
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "segformer/segformer_model.onnx")])
+@pytest.mark.parametrize("img_path", [os.path.join(data_path, "L0/temp_camvid.png")])
+@pytest.mark.parametrize("model_key", ["tlt_encode"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+def test_fp_engine(model_path, img_path, model_key, data_type, batch_size):
+    # Engine building part
+
+    tmp_onnx_file, file_format = decode_model(model_path, model_key)
+
+    output_engine_path = f"/tmp/segformer.{data_type}.engine"
+
+    builder = SegformerEngineBuilder(min_batch_size=1,
+                                     opt_batch_size=2,
+                                     max_batch_size=4)
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(output_engine_path, data_type)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = SegformerInferencer(output_engine_path, batch_size=batch_size)
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == 3, "Incorrect channel size"
+
+    dummy_images = []
+
+    # Load dummy image
+    for _ in range(batch_size):
+        dummy_image = Image.open(img_path).resize((TARGET_WIDTH, TARGET_HEIGHT))
+        dummy_image = np.asarray(dummy_image, np.float32)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+
+    y_pred = trt_infer.infer(dummy_images)
+    # Predictions are in shape (batch_size, 1, TARGET_HEIGHT, TARGET_WIDTH)
+    assert y_pred.shape == (batch_size, 1, TARGET_HEIGHT, TARGET_WIDTH), "Shape of prediction is incorrect"
+
+    for pred in y_pred:
+        # Store predictions as mask
+        pred = np.argmax(pred, axis=0).astype(np.uint8) * 255
+        # resize to original image size
+        pred = cv2.resize(pred, (w, h), interpolation=cv2.INTER_LINEAR)
+        output = Image.fromarray(pred.astype(np.uint8))
+        assert output.size == (TARGET_WIDTH, TARGET_HEIGHT), "Output image size is incorrect"

--- a/tests/ssd/__init__.py
+++ b/tests/ssd/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SSD Unit Tests."""

--- a/tests/ssd/test_dataloader.py
+++ b/tests/ssd/test_dataloader.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SSD Data Loading Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+import tempfile
+
+from nvidia_tao_deploy.cv.ssd.dataloader import SSDKITTILoader
+
+
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+CLASSMAP = {
+    "car": "car",
+    "bicycle": "bicycle",
+    "person": "person",
+    "road_sign": "road_sign"
+}
+
+KITTI_DICT = {
+    "0000": [
+        ["person", 0.00, 0, 0.00, 394.00, 321.00, 470.00, 387.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00],
+        ["car", 0.00, 0, 0.00, 549.00, 103.00, 569.00, 163.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+    ],
+    "0020": [
+        ["road_sign", 0.00, 0, 0.00, 212.00, 126.00, 239.00, 190.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+    ]
+}
+
+
+@pytest.mark.faster_rcnn
+@pytest.mark.parametrize("data_format", ["channels_first"])
+@pytest.mark.parametrize("num_channels", [1, 3]) # TODO: Add grayscale support
+@pytest.mark.parametrize("keep_aspect_ratio", [True, False])
+def test_dataloader(data_format, num_channels, keep_aspect_ratio):
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        image_dir = os.path.join(tmpdirname, "images")
+        label_dir = os.path.join(tmpdirname, "labels")
+        os.makedirs(image_dir, exist_ok=True)
+        os.makedirs(label_dir, exist_ok=True)
+
+        for k, v in KITTI_DICT.items():
+            # Load dummy image
+            img_width = np.random.randint(low=800, high=1000)
+            img_height = np.random.randint(low=500, high=600)
+
+            dummy_image = np.random.randint(low=0, high=255, size=(img_height, img_width, 3), dtype=np.uint8)
+            dummy_image = Image.fromarray(dummy_image)
+
+            # Save dummy image
+            dummy_image.save(os.path.join(image_dir, f"{k}.jpg"))
+
+            # Save dummy label
+            np.savetxt(os.path.join(label_dir, f"{k}.txt"), v, fmt="%s")
+    
+        dl = SSDKITTILoader(
+            shape=(num_channels, TARGET_HEIGHT, TARGET_WIDTH),
+            image_dirs=[image_dir],
+            label_dirs=[label_dir],
+            mapping_dict=CLASSMAP,
+            batch_size=1,
+            keep_aspect_ratio=keep_aspect_ratio,
+            dtype=np.float32)
+
+        for (imgs, labels) in dl:
+            assert labels.shape[-1] == 6, "Label dim does not match"
+
+            if data_format == "channels_first":
+                b, c, h, w = imgs.shape
+            else:
+                b, h, w, c = imgs.shape
+            
+            assert b == 1, "Batch size does not match"
+            assert c == num_channels, "Height does not match"
+            assert h == TARGET_HEIGHT, "Height does not match"
+            assert w == TARGET_WIDTH, "Height does not match"

--- a/tests/ssd/test_engine.py
+++ b/tests/ssd/test_engine.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SSD Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+
+from nvidia_tao_deploy.utils.decoding import decode_etlt
+from nvidia_tao_deploy.cv.ssd.engine_builder import SSDEngineBuilder
+from nvidia_tao_deploy.cv.ssd.inferencer import SSDInferencer
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+
+# UFF no longer supported in DLFW 24.06+
+# os.path.join(model_path, "ssd/ssd_its.etlt")
+@pytest.mark.ssd
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "ssd/ssd_onnx.etlt")])
+@pytest.mark.parametrize("img_path", [os.path.join(data_path, "L0/temp_its_mini.jpg")])
+@pytest.mark.parametrize("model_key", ["nvidia_tlt"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+def test_fp_engine(model_path, img_path, model_key, data_type, batch_size):
+    # Engine building part
+    if model_path.endswith("etlt"):
+        tmp_onnx_file, file_format = decode_etlt(model_path, model_key)
+    else:
+        raise ValueError(f"{model_path} has incorrect extension")
+
+    output_engine_path = f"/tmp/ssd.{data_type}.engine"
+
+    builder = SSDEngineBuilder(min_batch_size=1,
+                               opt_batch_size=2,
+                               max_batch_size=4)
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(output_engine_path, data_type)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = SSDInferencer(output_engine_path, batch_size=batch_size)
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert c == 3, "Incorrect channel size"
+
+    dummy_images = []
+
+    # Load dummy image
+    for _ in range(batch_size):
+        dummy_image = Image.open(img_path).resize((w, h))
+        dummy_image = np.asarray(dummy_image, np.float32)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+
+    y_pred = trt_infer.infer(dummy_images)
+    assert y_pred.shape[-1] == 6, "Shape of prediction is incorrect"

--- a/tests/ssd/test_ssd.py
+++ b/tests/ssd/test_ssd.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SSD workflow pipeline."""
+
+import pytest
+import os
+import subprocess
+import sys
+
+
+model_dir = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_dir = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+
+
+# UFF model no longer supported in DLFW 24.06+
+# (os.path.join(model_dir, "ssd/ssd_its.etlt"), os.path.join(model_dir, "ssd/ssd_spec.txt")
+@pytest.mark.ssd
+@pytest.mark.parametrize("model_tupl", [(os.path.join(model_dir, "ssd/ssd_resnet18_epoch_074.etlt"),
+                                        "nvidia_tao_deploy/cv/ssd/specs/experiment_spec.txt"
+                                         ),])
+@pytest.mark.parametrize("cal_img_dir", [os.path.join(data_dir, "L1/IVA-0010-02_1280_0_181016/eval_images_kitti")])
+@pytest.mark.parametrize("model_key", ["nvidia_tlt"])
+@pytest.mark.parametrize("data_type", ["int8"])
+@pytest.mark.parametrize("tmpdir", ["/tmp/ssd"])
+@pytest.mark.parametrize("max_batch_size", [4])
+@pytest.mark.parametrize("batch_size", [4])
+@pytest.mark.parametrize("batches", [200])
+def test_gen_trt_engine(model_tupl, cal_img_dir, model_key, data_type, tmpdir, max_batch_size, batch_size, batches):
+    os.makedirs(tmpdir, exist_ok=True)
+
+    model_path, spec_path = model_tupl
+    
+    # Check model file
+    if not os.path.exists(model_path):
+        model_dir_path = os.path.dirname(model_path)
+        print(f"\n{'='*80}")
+        print(f"ERROR: Model file not found: {model_path}")
+        print(f"{'='*80}")
+        if os.path.exists(model_dir_path):
+            print(f"\nContents of {model_dir_path}:")
+            try:
+                for item in sorted(os.listdir(model_dir_path)):
+                    item_path = os.path.join(model_dir_path, item)
+                    if os.path.isdir(item_path):
+                        print(f"  [DIR]  {item}")
+                    else:
+                        size = os.path.getsize(item_path)
+                        print(f"  [FILE] {item} ({size} bytes)")
+            except Exception as e:
+                print(f"  Error: {e}")
+        else:
+            print(f"\nDirectory does not exist: {model_dir_path}")
+        print(f"{'='*80}\n")
+    
+    # Check calibration directory
+    if not os.path.exists(cal_img_dir):
+        print(f"\n{'='*80}")
+        print(f"ERROR: Calibration directory not found: {cal_img_dir}")
+        print(f"{'='*80}")
+        parent_dir = os.path.dirname(cal_img_dir)
+        if os.path.exists(parent_dir):
+            print(f"\nContents of parent directory {parent_dir}:")
+            try:
+                for item in sorted(os.listdir(parent_dir)):
+                    print(f"  {item}")
+            except Exception as e:
+                print(f"  Error: {e}")
+        print(f"{'='*80}\n")
+    else:
+        # Check number of calibration images
+        try:
+            image_files = [f for f in os.listdir(cal_img_dir) if f.endswith(('.jpg', '.png', '.jpeg'))]
+            required_images = batch_size * batches
+            print(f"\nCalibration images: found {len(image_files)}, required {required_images}")
+            if len(image_files) < required_images:
+                print(f"WARNING: Insufficient calibration images!")
+        except Exception as e:
+            print(f"Error checking calibration images: {e}")
+
+    output_engine_path = os.path.join(tmpdir, os.path.basename(model_path).replace(".etlt", ".engine"))
+    output_data_path = os.path.join(tmpdir, "ssd.tensorfile")
+    output_cache_path = os.path.join(tmpdir, "ssd.bin")
+
+    # Create system call.
+    call = (
+        "python nvidia_tao_deploy/cv/ssd/entrypoint/ssd.py gen_trt_engine "
+        f"-m {model_path} "
+        f"-k {model_key} "
+        f"--data_type {data_type} "
+        f"-e {spec_path} "
+        f"--cal_data_file {output_data_path} "
+        f"--cal_cache_file {output_cache_path} "
+        f"--cal_image_dir {cal_img_dir} "
+        f"--engine_file {output_engine_path} "
+        f"--max_batch_size {max_batch_size} "
+        f"--batch_size {batch_size} "
+        f"--batches {batches} "
+        f"-r {tmpdir} "
+    )
+
+    print(call)
+    # Run the call as subprocess.
+    subprocess.check_call(call, shell=True, stdout=sys.stdout, stderr=sys.stdout)
+
+    # Check if there are any files.
+    if not os.path.exists(output_engine_path):
+        raise FileNotFoundError(f"{output_engine_path} does not exist")
+    if not os.path.exists(output_data_path):
+        raise FileNotFoundError(f"{output_data_path} does not exist")
+    if not os.path.exists(output_cache_path):
+        raise FileNotFoundError(f"{output_cache_path} does not exist")
+
+
+@pytest.mark.skip(reason="SSD evaluation depends on engine generation - skipping until INT8 calibration is fixed")
+@pytest.mark.ssd
+@pytest.mark.parametrize("model_path", [os.path.join("/tmp/ssd/ssd_resnet18_epoch_074.engine")])
+@pytest.mark.parametrize("img_dir", [os.path.join(data_dir, "L1/IVA-0010-02_1280_0_181016/eval_images_kitti")])
+@pytest.mark.parametrize("label_dir", [os.path.join(data_dir, "L1/IVA-0010-02_1280_0_181016/eval_labels_kitti")])
+@pytest.mark.parametrize("tmpdir", ["/tmp/ssd"])
+@pytest.mark.parametrize("batch_size", [4])
+def test_evaluate(model_path, img_dir, label_dir, tmpdir, batch_size):
+    os.makedirs(tmpdir, exist_ok=True)
+    
+    # Check if engine file exists (should be created by test_gen_trt_engine)
+    if not os.path.exists(model_path):
+        print(f"\n{'='*80}")
+        print(f"ERROR: Engine file not found: {model_path}")
+        print(f"{'='*80}")
+        engine_dir = os.path.dirname(model_path)
+        if os.path.exists(engine_dir):
+            print(f"\nContents of {engine_dir}:")
+            try:
+                for item in sorted(os.listdir(engine_dir)):
+                    item_path = os.path.join(engine_dir, item)
+                    if os.path.isdir(item_path):
+                        print(f"  [DIR]  {item}")
+                    else:
+                        size = os.path.getsize(item_path)
+                        print(f"  [FILE] {item} ({size} bytes)")
+            except Exception as e:
+                print(f"  Error: {e}")
+        print(f"NOTE: This test requires test_gen_trt_engine to run successfully first.")
+        print(f"{'='*80}\n")
+    
+    results_json_file = os.path.join(tmpdir, "results.json")
+    spec_path = os.path.join(model_dir, "ssd/ssd_spec.txt")
+    
+    # Check spec file
+    if not os.path.exists(spec_path):
+        print(f"\n{'='*80}")
+        print(f"ERROR: Spec file not found: {spec_path}")
+        print(f"{'='*80}")
+        spec_dir = os.path.dirname(spec_path)
+        if os.path.exists(spec_dir):
+            print(f"\nContents of {spec_dir}:")
+            try:
+                for item in sorted(os.listdir(spec_dir)):
+                    print(f"  {item}")
+            except Exception as e:
+                print(f"  Error: {e}")
+        print(f"{'='*80}\n")
+    # Create system call.
+    call = (
+        "python nvidia_tao_deploy/cv/ssd/entrypoint/ssd.py evaluate "
+        f"-m {model_path} "
+        f"-e {spec_path} "
+        f"-i {img_dir} "
+        f"-l {label_dir} "
+        f"-r {tmpdir} "
+        f"--batch_size {batch_size} "
+    )
+
+    print(call)
+    # Run the call as subprocess.
+    subprocess.check_call(call, shell=True, stdout=sys.stdout, stderr=sys.stdout)
+
+    # Check if there are any files.
+    if not os.path.exists(results_json_file):
+        raise FileNotFoundError(f"{results_json_file} does not exist")

--- a/tests/unet/__init__.py
+++ b/tests/unet/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""UNet Unit Tests."""

--- a/tests/unet/test_dataloader.py
+++ b/tests/unet/test_dataloader.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""UNet Data Loading Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+import tempfile
+
+from nvidia_tao_deploy.cv.unet.dataloader import UNetLoader
+
+
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+NUM_CLASSES = 2
+
+
+@pytest.mark.faster_rcnn
+@pytest.mark.parametrize("data_format", ["channels_first"])  # Always assume channels first
+@pytest.mark.parametrize("num_channels", [1, 3])  # Grayscale is can also be channel size 3
+@pytest.mark.parametrize("resize_method", ["bilinear", "BICUBIC"])
+@pytest.mark.parametrize("resize_padding", [True, False])
+@pytest.mark.parametrize("input_image_type", ["color", "grayscale"])
+def test_dataloader(data_format, num_channels, input_image_type, resize_method, resize_padding):
+    # Invalid scenario so skip
+    if num_channels == 1 and input_image_type == "color":
+        pytest.skip("input image type must be grayscale for channel size to be 1")
+
+    if data_format == "channels_first":
+        input_shape = (num_channels, TARGET_HEIGHT, TARGET_WIDTH)
+    else:
+        input_shape = (TARGET_HEIGHT, TARGET_WIDTH, num_channels)
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        image_dir = os.path.join(tmpdirname, "images")
+        label_dir = os.path.join(tmpdirname, "labels")
+        os.makedirs(image_dir, exist_ok=True)
+        os.makedirs(label_dir, exist_ok=True)
+
+        for i in range(3):
+            # Load dummy image
+            img_width = np.random.randint(low=800, high=1000)
+            img_height = np.random.randint(low=500, high=600)
+            
+            dummy_image = np.random.randint(low=0, high=255, size=(img_height, img_width, 3), dtype=np.uint8)
+            dummy_image = Image.fromarray(dummy_image)
+
+            # Save dummy image
+            dummy_image.save(os.path.join(image_dir, f"{i}.jpg"))
+
+            # Dummy mask label with near-center being 1
+            dummy_mask = np.zeros((img_height, img_width))
+            dummy_mask[262:282, 470:490] = 1
+            dummy_mask = Image.fromarray((dummy_mask * 255).astype(np.uint8))
+
+            # Save dummy mask
+            dummy_mask.save(os.path.join(label_dir, f"{i}.png"))
+
+        dl = UNetLoader(
+            input_shape,
+            [image_dir],
+            [label_dir],
+            NUM_CLASSES,
+            batch_size=1,
+            resize_method=resize_method,
+            preprocess="min_max_-1_1",
+            resize_padding=False,
+            model_arch="shufflenet",
+            input_image_type=input_image_type,
+            dtype=np.float32)
+
+        for (imgs, labels) in dl:
+            if data_format == "channels_first":
+                b, c, h, w = imgs.shape
+            else:
+                b, h, w, c = imgs.shape
+
+            assert b == 1, "Batch size does not match"
+            assert c == num_channels, "Height does not match"
+            assert h == TARGET_HEIGHT, "Height does not match"
+            assert w == TARGET_WIDTH, "Height does not match"
+
+            assert labels.shape[1:] == (TARGET_HEIGHT, TARGET_WIDTH), "Label dim does not match"

--- a/tests/unet/test_engine.py
+++ b/tests/unet/test_engine.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unet Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+
+from nvidia_tao_deploy.utils.decoding import decode_etlt
+from nvidia_tao_deploy.cv.unet.engine_builder import UNetEngineBuilder
+from nvidia_tao_deploy.cv.unet.inferencer import UNetInferencer
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+
+
+@pytest.mark.unet
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "unet/model.step-4772476.etlt")])
+@pytest.mark.parametrize("img_path", [os.path.join(data_path, "L0/temp_its_mini.jpg")])
+@pytest.mark.parametrize("model_key", ["tlt_encode"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("activation", ["sigmoid"])
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+def test_fp_engine(model_path, img_path, model_key, data_type, activation, batch_size):
+    # Engine building part
+    if model_path.endswith("etlt"):
+        tmp_onnx_file, file_format = decode_etlt(model_path, model_key)
+    else:
+        raise ValueError(f"{model_path} has incorrect extension")
+
+    output_engine_path = f"/tmp/unet.{data_type}.engine"
+
+    builder = UNetEngineBuilder(min_batch_size=1,
+                                opt_batch_size=2,
+                                max_batch_size=4)
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(output_engine_path, data_type)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = UNetInferencer(output_engine_path, batch_size=batch_size, activation=activation)
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == 3, "Incorrect channel size"
+
+    # Load dummy image
+    dummy_image = Image.open(img_path).resize((TARGET_WIDTH, TARGET_HEIGHT))
+    dummy_image = np.asarray(dummy_image, np.float32)
+
+    dummy_images = []
+
+    # Load dummy image
+    for _ in range(batch_size):
+        dummy_image = Image.open(img_path).resize((TARGET_WIDTH, TARGET_HEIGHT))
+        dummy_image = np.asarray(dummy_image, np.float32)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+
+    y_pred = trt_infer.infer(dummy_images)
+    assert y_pred.shape == (batch_size, TARGET_HEIGHT, TARGET_WIDTH), "Shape of prediction is incorrect"

--- a/tests/visual_changenet/__init__.py
+++ b/tests/visual_changenet/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Visual ChangeNet unit tests."""

--- a/tests/visual_changenet/test_dataloader.py
+++ b/tests/visual_changenet/test_dataloader.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Visual ChangeNet-Classification Data Loading Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+import tempfile
+import pandas as pd
+from omegaconf import OmegaConf
+from tqdm import tqdm
+
+from nvidia_tao_deploy.config.visual_changenet.default_config import ExperimentConfig
+
+from nvidia_tao_deploy.cv.optical_inspection.dataloader import OpticalInspectionDataLoader
+
+
+tmp_top_obj = tempfile.TemporaryDirectory()
+tmp_top_dir = tmp_top_obj.name
+csv_file = os.path.join(tmp_top_dir, 'test_data.csv')
+SAMPLES = 10
+BATCH_SIZE = 2
+IMAGE_WIDTH = 128
+IMAGE_HEIGHT = 128
+NUM_INPUT = 4
+
+
+@pytest.fixture
+def _test_dir():
+    if not os.path.exists(tmp_top_dir):
+        os.makedirs(tmp_top_dir)
+    tmp_test_dir = os.path.join(tmp_top_dir, "test")
+    tmp_golden_dir = os.path.join(tmp_top_dir, "golden")
+    os.makedirs(tmp_test_dir, exist_ok=True)
+    os.makedirs(tmp_golden_dir, exist_ok=True)
+
+    test_data = np.random.rand(IMAGE_HEIGHT, IMAGE_WIDTH, 3) * 255
+    test_data = test_data.astype(np.uint8)
+    im = Image.fromarray(test_data)
+    lighting = ['LowAngleLight', 'SolderLight', 'UniformLight', 'WhiteLight']
+    labels = ['PASS', 'MISSING']
+    total_samples = SAMPLES
+    comp_name = 'test'
+    csv_data = []
+    for sample in range(total_samples):
+        for label in labels:
+            for light in lighting:
+                save_light = comp_name + '_' + light + '.jpg'
+                im.save(os.path.join(tmp_test_dir, save_light))
+                im.save(os.path.join(tmp_golden_dir, save_light))
+                csv_data.append({
+                    'input_path': 'test',
+                    'golden_path': 'golden',
+                    'label': label,
+                    'object_name': comp_name
+                })
+    
+    df = pd.DataFrame(csv_data)
+    df.to_csv(csv_file, index=False)
+    yield csv_file
+
+
+@pytest.fixture
+def _test_exp_spec():
+    experiment_config = OmegaConf.structured(ExperimentConfig())
+    experiment_config["dataset"]['classify']["train_dataset"]["csv_path"] = csv_file
+    experiment_config["dataset"]['classify']["validation_dataset"]["csv_path"] = csv_file
+    experiment_config["dataset"]['classify']["test_dataset"]["csv_path"] = csv_file
+    experiment_config["dataset"]['classify']["infer_dataset"]["csv_path"] = csv_file
+    experiment_config["dataset"]['classify']["train_dataset"]["images_dir"] = tmp_top_dir
+    experiment_config["dataset"]['classify']["validation_dataset"]["images_dir"] = tmp_top_dir
+    experiment_config["dataset"]['classify']["test_dataset"]["images_dir"] = tmp_top_dir
+    experiment_config["dataset"]['classify']["infer_dataset"]["images_dir"] = tmp_top_dir
+    experiment_config["dataset"]['classify']["num_input"] = NUM_INPUT
+    experiment_config["dataset"]['classify']["image_width"] = IMAGE_WIDTH
+    experiment_config["dataset"]['classify']["image_height"] = IMAGE_HEIGHT
+    experiment_config["dataset"]['classify']["input_map"] = {'LowAngleLight': 0,
+                                                        'SolderLight': 1,
+                                                        'UniformLight': 2,
+                                                        'WhiteLight': 3
+                                                        }
+    experiment_config["dataset"]['classify']["concat_type"] = 'linear'
+    experiment_config["dataset"]['classify']["image_ext"] = '.jpg'
+    experiment_config["dataset"]['classify']["batch_size"] = BATCH_SIZE
+
+    experiment_config["results_dir"] = tmp_top_dir
+
+    yield experiment_config
+
+
+@pytest.mark.parametrize("split", ['train', 'valid', 'test', 'infer'])
+@pytest.mark.parametrize("sample", [True, False])
+@pytest.mark.cv_unit
+def test_build_dataloader(_test_dir, _test_exp_spec, split, sample):
+
+    dataloader = OpticalInspectionDataLoader(
+        csv_file=_test_exp_spec.dataset.classify.infer_dataset.csv_path,
+        input_data_path=_test_exp_spec.dataset.classify.infer_dataset.images_dir,
+        train=False,
+        data_config=_test_exp_spec.dataset.classify,
+        batch_size=_test_exp_spec.dataset.classify.batch_size
+    )
+    total_num_samples = len(dataloader)
+    for unit_batch, golden_batch in tqdm(dataloader, total=total_num_samples):
+        assert unit_batch.shape[0] == BATCH_SIZE, "Incorrect batch size"
+        assert unit_batch.shape[2] == _test_exp_spec["dataset"]['classify']["num_input"] * _test_exp_spec["dataset"]['classify']["image_height"], "Incorrect height"
+        assert unit_batch.shape[3] == _test_exp_spec["dataset"]['classify']["image_width"], "Incorrect width"
+        assert unit_batch.shape == golden_batch.shape, "Input shapes do not match for test and golden sample"
+
+    tmp_top_obj.cleanup()

--- a/tests/visual_changenet/test_dataloader_segment.py
+++ b/tests/visual_changenet/test_dataloader_segment.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Visual ChangeNet-Segmentation Data Loading Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+import tempfile
+import pandas as pd
+from omegaconf import OmegaConf
+from tqdm import tqdm
+
+from nvidia_tao_deploy.config.visual_changenet.default_config import ExperimentConfig
+from nvidia_tao_deploy.cv.visual_changenet.segmentation.dataloader import ChangeNetDataLoader as ChangeNetSegmentDataLoader
+
+
+tmp_top_obj = tempfile.TemporaryDirectory()
+tmp_top_dir = tmp_top_obj.name
+SAMPLES = 10
+BATCH_SIZE = 2
+OUTPUT_SHAPE = 256
+LABEL_TRANSFORM = 'norm'
+DATASET = 'CNDataset'
+IMG_FOLDER_NAME = 'A'
+CHANGE_FOLDER_NAME = 'B'
+LABEL_FOLDER_NAME = 'label'
+LIST_FOLDER_NAME = 'list'
+
+
+@pytest.fixture
+def _test_dir():
+
+    if not os.path.exists(tmp_top_dir):
+        os.makedirs(tmp_top_dir)
+    tmp_test_dir = os.path.join(tmp_top_dir, IMG_FOLDER_NAME)
+    tmp_golden_dir = os.path.join(tmp_top_dir, CHANGE_FOLDER_NAME)
+    tmp_list_dir = os.path.join(tmp_top_dir, LIST_FOLDER_NAME)
+    tmp_label_dir = os.path.join(tmp_top_dir, LABEL_FOLDER_NAME)
+
+    os.makedirs(tmp_test_dir, exist_ok=True)
+    os.makedirs(tmp_golden_dir, exist_ok=True)
+    os.makedirs(tmp_list_dir, exist_ok=True)
+    os.makedirs(tmp_label_dir, exist_ok=True)
+
+    #Input images
+    test_data = np.random.rand(OUTPUT_SHAPE, OUTPUT_SHAPE, 3) * 255
+    test_data = test_data.astype(np.uint8)
+    im = Image.fromarray(test_data)
+    #GT Label image
+    label_data = np.zeros((OUTPUT_SHAPE, OUTPUT_SHAPE))
+    label_data = label_data.astype(np.uint8)
+    im_label = Image.fromarray(label_data)
+    
+    total_samples = SAMPLES
+    txt_data = []
+    for sample in range(total_samples):
+        im.save(os.path.join(tmp_test_dir, str(sample)+'.png'))
+        im.save(os.path.join(tmp_golden_dir, str(sample)+'.png'))
+        im_label.save(os.path.join(tmp_label_dir, str(sample)+'.png'))
+        txt_data.append(str(sample)+'.png')
+    
+    splits = ['train', 'val', 'test']
+    for split in splits:
+        txt_file_name = os.path.join(tmp_list_dir, split+'.txt')
+        with open (txt_file_name ,'w') as f:
+            for data in txt_data:
+                f.write(f"{data}\n")
+
+
+@pytest.fixture
+def _test_exp_spec():
+    experiment_config = OmegaConf.structured(ExperimentConfig())
+    experiment_config["dataset"]['segment']["root_dir"] = tmp_top_dir
+    experiment_config["dataset"]['segment']["label_transform"] = LABEL_TRANSFORM
+    experiment_config["dataset"]['segment']["img_size"] = OUTPUT_SHAPE
+    experiment_config["dataset"]['segment']["dataset"] = DATASET
+    experiment_config["dataset"]['segment']["image_folder_name"] = IMG_FOLDER_NAME
+    experiment_config["dataset"]['segment']["change_image_folder_name"] = CHANGE_FOLDER_NAME
+    experiment_config["dataset"]['segment']["list_folder_name"] = LIST_FOLDER_NAME
+    experiment_config["dataset"]['segment']["annotation_folder_name"] = LABEL_FOLDER_NAME
+    experiment_config["dataset"]['segment']["label_suffix"] = '.png'
+    experiment_config["dataset"]['segment']["batch_size"] = BATCH_SIZE
+
+    experiment_config["results_dir"] = tmp_top_dir
+
+    yield experiment_config
+
+
+@pytest.mark.parametrize("split", ['train', 'valid', 'test', 'infer'])
+@pytest.mark.parametrize("sample", [True, False])
+@pytest.mark.cv_unit
+def test_build_dataloader(_test_dir, _test_exp_spec, split, sample):
+
+    dataloader = ChangeNetSegmentDataLoader(
+        dataset_config=_test_exp_spec.dataset.segment,
+        dtype=np.float32,
+        mode='test',
+        split=_test_exp_spec.dataset.segment.test_split
+    )
+
+    total_num_samples = len(dataloader)
+
+    for idx, (img_1, img_2, label) in tqdm(enumerate(dataloader), total=total_num_samples):
+        assert img_1.shape[0] == BATCH_SIZE, "Incorrect batch size"
+        assert img_1.shape[2] == _test_exp_spec["dataset"]['segment']["img_size"], "Incorrect height"
+        assert img_1.shape[3] == _test_exp_spec["dataset"]['segment']["img_size"], "Incorrect width"
+        assert img_1.shape == img_2.shape, "Input images do not match in size"
+        assert label.shape[0] == BATCH_SIZE, "Incorrect batch size"
+        assert label.shape[1] == _test_exp_spec["dataset"]['segment']["img_size"], "Incorrect height"
+        assert label.shape[2] == _test_exp_spec["dataset"]['segment']["img_size"], "Incorrect width"
+
+    tmp_top_obj.cleanup()

--- a/tests/visual_changenet/test_engine.py
+++ b/tests/visual_changenet/test_engine.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Visual ChangeNet-Classification Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+
+import numpy as np
+from PIL import Image
+from nvidia_tao_deploy.engine.builder import EngineBuilder
+import tensorrt as trt
+from tqdm import tqdm
+
+from nvidia_tao_deploy.utils.decoding import decode_etlt
+from nvidia_tao_deploy.cv.visual_changenet.classification.inferencer import ChangeNetInferencer as ChangeNetClassifyInferencer
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/changenet/classify/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+TARGET_WIDTH = 128
+TARGET_HEIGHT = 128
+OUTPUT_SHAPE = (1, 1)
+
+
+def load_engine(engine_path):
+    """Check load engine.
+
+    Args:
+        engine_path(str): Path to the engine.
+
+    Return:
+        engine: Return TRT engine.
+    """
+    trt_logger = trt.Logger(trt.Logger.WARNING)
+    trt_runtime = trt.Runtime(trt_logger)
+    trt.init_libnvinfer_plugins(trt_logger, namespace="")
+    with open(engine_path, 'rb') as f:
+        engine_data = f.read()
+    engine = trt_runtime.deserialize_cuda_engine(engine_data)
+    return engine
+
+
+@pytest.mark.visual_changenet
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "changenet-classify_1light.onnx")])
+@pytest.mark.parametrize("img_path", [os.path.join(data_path, "L0/C48@1_SolderLight.jpg")])
+@pytest.mark.parametrize("batch_size", [4])
+@pytest.mark.parametrize("difference_module", ['euclidean'])
+@pytest.mark.parametrize("data_type", ["fp32"])
+def test_fp_engine(model_path, data_type, batch_size, img_path, difference_module):
+    # Engine building part
+
+    tmp_onnx_file = model_path
+    file_format = "onnx"
+
+    output_engine_path = f"/tmp/changnet.{data_type}.engine"
+
+    builder = EngineBuilder(min_batch_size=batch_size,
+                            opt_batch_size=batch_size,
+                            max_batch_size=batch_size,
+                            batch_size=batch_size)
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(
+        output_engine_path,
+        data_type,
+    )
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    trt_infer = ChangeNetClassifyInferencer(
+            engine_path=output_engine_path,
+            batch_size=batch_size,
+            diff_module=difference_module
+        )
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+    c1, h1, w1 = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size for input 1"
+    assert w == TARGET_WIDTH, "Incorrect width size for input 1"
+    assert c == 3, "Incorrect channel size for input 1"
+
+    assert h1 == TARGET_HEIGHT, "Incorrect height size for input 2"
+    assert w1 == TARGET_WIDTH, "Incorrect width size for input 2"
+    assert c1 == 3, "Incorrect channel size for input 2"
+
+    # Load dummy image
+    dummy_images = []
+    dummy_images1 = []
+    for _ in range(batch_size):
+        dummy_image = Image.open(img_path).resize((TARGET_HEIGHT, TARGET_WIDTH))
+        dummy_image = np.asarray(dummy_image, np.float32)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+        dummy_images1.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+    dummy_images1 = np.stack(dummy_images1, axis=0)
+
+    results = trt_infer.infer([dummy_images, dummy_images1])
+    assert results.shape == (batch_size,) + OUTPUT_SHAPE, "Incorrect output shape"
+
+    engine = load_engine(output_engine_path)
+    assert type(engine) == trt.tensorrt.ICudaEngine, (
+        "CUDA engine type failed."
+    )
+    del engine

--- a/tests/visual_changenet/test_engine_segment.py
+++ b/tests/visual_changenet/test_engine_segment.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Visual ChangeNet-Segmentation Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+
+import numpy as np
+from PIL import Image
+from nvidia_tao_deploy.engine.builder import EngineBuilder
+import tensorrt as trt
+
+from nvidia_tao_deploy.cv.visual_changenet.segmentation.inferencer import ChangeNetInferencer as ChangeNetSegmentInferencer
+
+
+model_path_segment = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/changenet/segment-levir-cd/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+INPUT_SHAPE = 256
+NUM_CLASSES = 2
+OUTPUT_SHAPE = (2, INPUT_SHAPE, INPUT_SHAPE)
+
+
+def load_engine(engine_path):
+    """Check load engine.
+
+    Args:
+        engine_path(str): Path to the engine.
+
+    Return:
+        engine: Return TRT engine.
+    """
+    trt_logger = trt.Logger(trt.Logger.WARNING)
+    trt_runtime = trt.Runtime(trt_logger)
+    trt.init_libnvinfer_plugins(trt_logger, namespace="")
+    with open(engine_path, 'rb') as f:
+        engine_data = f.read()
+    engine = trt_runtime.deserialize_cuda_engine(engine_data)
+    return engine
+
+
+@pytest.mark.visual_changenet
+@pytest.mark.parametrize("model_path", [os.path.join(model_path_segment, "changenet_segment.onnx")])
+@pytest.mark.parametrize("img_path", [os.path.join(data_path, "L0/test_1_2.png")])
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+@pytest.mark.parametrize("data_type", ["fp32"])
+def test_fp_engine(model_path, data_type, batch_size, img_path):
+    # Engine building part
+
+    tmp_onnx_file = model_path
+    file_format = "onnx"
+
+    output_engine_path = f"/tmp/changnet.{data_type}.engine"
+
+    builder = EngineBuilder(min_batch_size=1,
+                            opt_batch_size=2,
+                            max_batch_size=4,
+                            batch_size=batch_size)
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(
+        output_engine_path,
+        data_type,
+    )
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    trt_infer = ChangeNetSegmentInferencer(
+                engine_path=output_engine_path,
+                batch_size=batch_size,
+                n_class=NUM_CLASSES,
+                mode='predict'
+            )
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+    c1, h1, w1 = trt_infer.input_tensors[1].shape
+
+    assert h == INPUT_SHAPE, "Incorrect height size for input 1"
+    assert w == INPUT_SHAPE, "Incorrect width size for input 1"
+    assert c == 3, "Incorrect channel size for input 1"
+
+    assert h1 == INPUT_SHAPE, "Incorrect height size for input 2"
+    assert w1 == INPUT_SHAPE, "Incorrect width size for input 2"
+    assert c1 == 3, "Incorrect channel size for input 2"
+
+    # Load dummy images
+    dummy_images = []
+    dummy_images1 = []
+    for _ in range(batch_size):
+        dummy_image = Image.open(img_path).resize((INPUT_SHAPE, INPUT_SHAPE))
+        dummy_image = np.asarray(dummy_image, np.float32)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+        dummy_images1.append(dummy_image)
+
+    # Add batch dim
+    dummy_images = np.stack(dummy_images, axis=0)
+    dummy_images1 = np.stack(dummy_images1, axis=0)
+
+    results = trt_infer.infer([dummy_images, dummy_images1])
+    assert results.shape == (batch_size,) + OUTPUT_SHAPE, "Shape of prediction is incorrect"
+
+    engine = load_engine(output_engine_path)
+    assert type(engine) == trt.tensorrt.ICudaEngine, (
+        "CUDA engine type failed."
+    )
+    del engine

--- a/tests/yolo_v3/__init__.py
+++ b/tests/yolo_v3/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""YOLO_v3 Unit Tests."""

--- a/tests/yolo_v3/test_dataloader.py
+++ b/tests/yolo_v3/test_dataloader.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""YOLOv3 Data Loading Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+import tempfile
+
+from nvidia_tao_deploy.cv.yolo_v3.dataloader import YOLOv3KITTILoader
+
+
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+CLASSMAP = {
+    "car": "car",
+    "bicycle": "bicycle",
+    "person": "person",
+    "road_sign": "road_sign"
+}
+
+KITTI_DICT = {
+    "0000": [
+        ["person", 0.00, 0, 0.00, 394.00, 321.00, 470.00, 387.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00],
+        ["car", 0.00, 0, 0.00, 549.00, 103.00, 569.00, 163.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+    ],
+    "0020": [
+        ["road_sign", 0.00, 0, 0.00, 212.00, 126.00, 239.00, 190.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+    ]
+}
+
+
+@pytest.mark.yolo_v3
+@pytest.mark.parametrize("data_format", ["channels_first"])
+@pytest.mark.parametrize("num_channels", [1, 3])
+def test_dataloader(data_format, num_channels):
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        image_dir = os.path.join(tmpdirname, "images")
+        label_dir = os.path.join(tmpdirname, "labels")
+        os.makedirs(image_dir, exist_ok=True)
+        os.makedirs(label_dir, exist_ok=True)
+
+        for k, v in KITTI_DICT.items():
+            # Load dummy image
+            img_width = np.random.randint(low=800, high=1000)
+            img_height = np.random.randint(low=500, high=600)
+
+            dummy_image = np.random.randint(low=0, high=255, size=(img_height, img_width, 3), dtype=np.uint8)
+            dummy_image = Image.fromarray(dummy_image)
+
+            # Save dummy image
+            dummy_image.save(os.path.join(image_dir, f"{k}.jpg"))
+
+            # Save dummy label
+            np.savetxt(os.path.join(label_dir, f"{k}.txt"), v, fmt="%s")
+    
+        dl = YOLOv3KITTILoader(
+            shape=(num_channels, TARGET_HEIGHT, TARGET_WIDTH),
+            image_dirs=[image_dir],
+            label_dirs=[label_dir],
+            mapping_dict=CLASSMAP,
+            batch_size=1,
+            dtype=np.float32)
+
+        for (imgs, labels) in dl:
+            assert labels.shape[-1] == 6, "Label dim does not match"
+
+            if data_format == "channels_first":
+                b, c, h, w = imgs.shape
+            else:
+                b, h, w, c = imgs.shape
+            
+            assert b == 1, "Batch size does not match"
+            assert c == num_channels, "Height does not match"
+            assert h == TARGET_HEIGHT, "Height does not match"
+            assert w == TARGET_WIDTH, "Height does not match"

--- a/tests/yolo_v3/test_engine.py
+++ b/tests/yolo_v3/test_engine.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""YOLOv3 Engine Building and Inferencer Unit Tests."""
+
+import pytest
+import os
+import numpy as np
+from PIL import Image
+
+from nvidia_tao_deploy.utils.decoding import decode_etlt
+from nvidia_tao_deploy.cv.yolo_v3.engine_builder import YOLOv3EngineBuilder
+from nvidia_tao_deploy.cv.yolo_v3.inferencer import YOLOv3Inferencer
+
+
+model_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/models/"
+data_path = "/home/scratch.metropolis2/tao_ci/tao_deploy/data/"
+TARGET_WIDTH = 960
+TARGET_HEIGHT = 544
+
+
+@pytest.mark.yolo_v3
+@pytest.mark.parametrize("model_path", [os.path.join(model_path, "yolo_v3/yolov3_resnet18.etlt")])
+@pytest.mark.parametrize("img_path", [os.path.join(data_path, "L0/temp_its_mini.jpg")])
+@pytest.mark.parametrize("model_key", ["nvidia_tlt"])
+@pytest.mark.parametrize("data_type", ["fp32"])
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+def test_fp_engine(model_path, img_path, model_key, data_type, batch_size):
+    # Engine building part
+    if model_path.endswith("etlt"):
+        tmp_onnx_file, file_format = decode_etlt(model_path, model_key)
+    else:
+        raise ValueError(f"{model_path} has incorrect extension")
+
+    output_engine_path = f"/tmp/yolo_v3.{data_type}.engine"
+
+    builder = YOLOv3EngineBuilder(min_batch_size=1,
+                                  opt_batch_size=2,
+                                  max_batch_size=4)
+    builder.create_network(tmp_onnx_file, file_format)
+    builder.create_engine(output_engine_path, data_type)
+
+    assert os.path.exists(output_engine_path), "Engine was not generated"
+
+    # Inferencer part
+    trt_infer = YOLOv3Inferencer(output_engine_path, batch_size=batch_size)
+
+    # Check engine model shape
+    c, h, w = trt_infer.input_tensors[0].shape
+
+    assert h == TARGET_HEIGHT, "Incorrect height size"
+    assert w == TARGET_WIDTH, "Incorrect width size"
+    assert c == 3, "Incorrect channel size"
+
+    dummy_images = []
+
+    # Load dummy image
+    for _ in range(batch_size):
+        dummy_image = Image.open(img_path).resize((TARGET_WIDTH, TARGET_HEIGHT))
+        dummy_image = np.asarray(dummy_image, np.float32)
+        dummy_image = np.transpose(dummy_image, (2, 0, 1))
+        dummy_images.append(dummy_image)
+
+    y_pred = trt_infer.infer(dummy_images)
+    assert y_pred.shape[-1] == 6, "Shape of prediction is incorrect"


### PR DESCRIPTION
# What does this PR do ?

Guard the optional `nvidia_tao_core.telemetry` import in the TAO Deploy CLI entrypoints so the package works when telemetry is unavailable (e.g. the OSS/public builds where `nvidia_tao_core.telemetry` is not shipped).

**Collection**: TAO Deploy (`nvidia_tao_deploy/cv/common/entrypoint`)

# Changelog
- `nvidia_tao_deploy/cv/common/entrypoint/entrypoint_hydra.py`: wrapped `from nvidia_tao_core.telemetry.telemetry import send_telemetry_data` in a `try/except ImportError`, setting `send_telemetry_data = None` and a new `TELEMETRY_AVAILABLE` flag.
- `entrypoint_hydra.py`: gated the telemetry-send block on `TELEMETRY_AVAILABLE` (logs "Telemetry module not available; skipping telemetry reporting." when absent).
- `nvidia_tao_deploy/cv/common/entrypoint/entrypoint_proto.py`: same import guard + `TELEMETRY_AVAILABLE` flag.
- `entrypoint_proto.py`: gated the telemetry-send block on `TELEMETRY_AVAILABLE`.
- No behavioral change when telemetry is available: data is still collected and sent exactly as before.

# Usage
Entrypoints now import and run even without `nvidia_tao_core.telemetry` installed:

```python
# Previously raised: ModuleNotFoundError: No module named 'nvidia_tao_core.telemetry'
# Now imports cleanly and simply skips telemetry when the module is absent.
from nvidia_tao_deploy.cv.common.entrypoint import entrypoint_hydra  # noqa

# e.g. CLI smoke test used by CI:
#   efficientdet_tf2 --help
#   deformable_detr --help
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](FIXME)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install?
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries?

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](FIXME) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
* `get_device_details` is unaffected — it is imported from `nvidia_tao_deploy.cv.common.telemetry.nvml_utils` (in-repo), not from `nvidia_tao_core`.
* Companion guard for the same telemetry module was applied in `tao-core` (`api_utils/entrypoint_mimicker/vlm_entrypoint.py`); this PR covers TAO Deploy's own entrypoints.