### PR TITLE
Release 7.1.0: sync from GitLab release/7.1.0

### DIFF
--- a/nvidia_tao_deploy/config/common/common_config.py
+++ b/nvidia_tao_deploy/config/common/common_config.py
@@ -27,6 +27,59 @@ class CuDNNConfig:
 
 
 @dataclass
+class CheckpointerConfig:
+    """Config for monitoring a metric and saving the best checkpoint(s).
+
+    By default this is additive to periodic checkpointing: when ``enable_topk`` is
+    set, a separate monitored ``ModelCheckpoint`` ranks checkpoints by a metric.
+    Set ``replace_periodic`` to keep only the single metric-best checkpoint instead;
+    that checkpoint then owns the existing ``*_latest`` symlink. Exception
+    checkpointing remains independent in either mode.
+    """
+
+    enable_topk: bool = BOOL_FIELD(
+        value=False, default_value=False,
+        display_name="Enable best-checkpoint saving",
+        description="Save checkpoint(s) ranked by a monitored metric. This is "
+                    "additive to periodic checkpoints unless replace_periodic is enabled.",
+    )
+    replace_periodic: bool = BOOL_FIELD(
+        value=False, default_value=False,
+        display_name="Replace periodic checkpoints",
+        description="When best-checkpoint saving is enabled, replace the unbounded "
+                    "periodic checkpoint callback with one metric-best checkpoint and "
+                    "make it own the existing *_latest symlink. This mode always keeps "
+                    "exactly one best checkpoint, regardless of save_top_k.",
+    )
+    monitor: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="Monitored metric",
+        description="Override the network's default monitored metric (e.g. val_loss, "
+                    "val_acc, val_miou, mAP). Leave unset to use the network default.",
+    )
+    mode: Optional[str] = STR_FIELD(
+        value=None, valid_options="min,max",
+        display_name="Monitor mode",
+        description="Override direction. 'min' for losses, 'max' for accuracy/mAP/mIoU. "
+                    "Leave unset to use the network default.",
+    )
+    save_top_k: int = INT_FIELD(
+        value=1, default_value=1, valid_min=1,
+        display_name="Number of best checkpoints",
+        description="How many best checkpoints to keep (1 = only the single best).",
+    )
+    filename: str = STR_FIELD(
+        value="model_best_{epoch:03d}", default_value="model_best_{epoch:03d}",
+        display_name="Best-checkpoint filename pattern",
+    )
+    dirpath: Optional[str] = STR_FIELD(
+        value=None,
+        description="Directory for best checkpoints. Defaults to results_dir.",
+    )
+    auto_insert_metric_name: bool = BOOL_FIELD(value=False, default_value=False)
+
+
+@dataclass
 class TrainConfig:
     """Common train experiment config."""
 
@@ -104,6 +157,7 @@ class TrainConfig:
         description="""
         Path to where all the assets generated from a task are stored.
         """)
+    checkpointer: CheckpointerConfig = DATACLASS_FIELD(CheckpointerConfig())
 
 
 @dataclass

--- a/nvidia_tao_deploy/config/dino/model.py
+++ b/nvidia_tao_deploy/config/dino/model.py
@@ -68,6 +68,13 @@ SUPPORTED_BACKBONES = [
 class DINOModelConfig:
     """DINO model config."""
 
+    precise_msda: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="precise MSDeformAttn",
+        description="Schema-compat mirror of the training config's deterministic MSDeformAttn "
+                    "backward flag. Training-only; ignored at inference/TRT."
+    )
     pretrained_backbone_path: Optional[str] = STR_FIELD(
         value=None,
         default_value="",

--- a/nvidia_tao_deploy/config/grounding_dino/dataset.py
+++ b/nvidia_tao_deploy/config/grounding_dino/dataset.py
@@ -223,6 +223,17 @@ class GDINODatasetConfig:
         valid_max="inf",
         display_name="max labels"
     )
+    deterministic_label_order: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="deterministic label order",
+        description=(
+            "Training-time flag that canonicalizes the ODVG caption/label order with sorted() "
+            "so caption token order is reproducible across process launches (independent of "
+            "PYTHONHASHSEED). Present here for train/deploy spec parity so a training spec loads "
+            "without error; it has no effect on TensorRT evaluation/inference."
+        )
+    )
     eval_class_ids: Optional[List[int]] = LIST_FIELD(
         arrList=None,
         default_value=[1],

--- a/nvidia_tao_deploy/config/mask2former/model.py
+++ b/nvidia_tao_deploy/config/mask2former/model.py
@@ -368,6 +368,13 @@ class Backbone:
 class Mask2FormerModelConfig:
     """Mask2former model config."""
 
+    precise_msda: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="precise MSDeformAttn",
+        description="Schema-compat mirror of the training config's deterministic MSDeformAttn "
+                    "backward flag. Training-only; ignored at inference/TRT."
+    )
     export: bool = BOOL_FIELD(
         value=False,
         default_value=False,

--- a/nvidia_tao_deploy/config/multimodal/clip/default_config.py
+++ b/nvidia_tao_deploy/config/multimodal/clip/default_config.py
@@ -168,6 +168,15 @@ class CLIPDataPathConfig:
                     "Caption filename = image_basename + caption_file_suffix (e.g., 'image.png' -> 'image.txt').",
         display_name="Caption File Suffix",
     )
+    attribute_pairs_file: Optional[str] = STR_FIELD(
+        value=None,
+        default_value=None,
+        description=(
+            "Optional split-aligned pairs metadata file used for "
+            "metadata-aware validation."
+        ),
+        display_name="Attribute Pairs File",
+    )
 
 
 @dataclass
@@ -231,6 +240,15 @@ class CLIPTrainDataConfig(CLIPDataLoaderConfig):
         valid_options="wds,custom",
         description="Dataset type: 'custom' for filesystem-based or 'wds' for WebDataset.",
         display_name="Dataset Type",
+    )
+    include_attribute_metadata: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        description=(
+            "Include image/text attribute tensors in custom training batches. "
+            "Required when siglip_loss_mask_mode is enabled."
+        ),
+        display_name="Include Attribute Metadata",
     )
     wds: Optional[CLIPWDSConfig] = DATACLASS_FIELD(
         CLIPWDSConfig(),
@@ -366,6 +384,35 @@ class CLIPTrainConfig(TrainConfig):
         valid_options="siglip,clip",
         description="Contrastive loss function: 'siglip' (sigmoid) or 'clip' (softmax).",
         display_name="Loss Type",
+    )
+    siglip_loss_dist_impl: str = STR_FIELD(
+        value="gather",
+        default_value="gather",
+        valid_options="bidir,shift,reduce,gather,local",
+        description=(
+            "Distributed implementation for SigLIP loss negative exchange. "
+            "Use 'local' to disable cross-rank negative exchange. "
+            "Only used when loss_type is 'siglip'."
+        ),
+        display_name="SigLIP Loss Distributed Implementation",
+    )
+    siglip_loss_mask_mode: str = STR_FIELD(
+        value="none",
+        default_value="none",
+        valid_options=(
+            "none,attribute_match_ignore,"
+            "attribute_plus_accessory_match_ignore"
+        ),
+        description=(
+            "Optional metadata-based masking mode for SigLIP loss. "
+            "'none' keeps existing behavior; 'attribute_match_ignore' ignores "
+            "off-diagonal negatives whose attributes match the text query; "
+            "'attribute_plus_accessory_match_ignore' additionally requires "
+            "all query accessories to be present in the image. "
+            "Metadata masking requires include_attribute_metadata=True on the "
+            "custom training dataset and a supported distributed implementation."
+        ),
+        display_name="SigLIP Loss Mask Mode",
     )
     precision: str = STR_FIELD(
         value="fp16",

--- a/nvidia_tao_deploy/config/oneformer/model.py
+++ b/nvidia_tao_deploy/config/oneformer/model.py
@@ -635,6 +635,13 @@ class TextEncoder:
 class OneFormerModelConfig:
     """OneFormer model config."""
 
+    precise_msda: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="precise MSDeformAttn",
+        description="Schema-compat mirror of the training config's deterministic MSDeformAttn "
+                    "backward flag. Training-only; ignored at inference/TRT."
+    )
     sem_seg_head: SemanticSegmentationHead = DATACLASS_FIELD(
         SemanticSegmentationHead(),
         description="Semantic segmentation head.",

--- a/nvidia_tao_deploy/config/segformer/default_config.py
+++ b/nvidia_tao_deploy/config/segformer/default_config.py
@@ -128,6 +128,11 @@ class BackboneConfig:
             "fan_base_16_p4_hybrid",
             "vit_large_nvdinov2",
             "vit_giant_nvdinov2",
+            "vit_small_dinov3",
+            "vit_small_plus_dinov3",
+            "vit_base_dinov3",
+            "vit_large_dinov3",
+            "vit_huge_plus_dinov3",
             "vit_base_nvclip_16_siglip",
             "vit_huge_nvclip_14_siglip"
         ]),

--- a/nvidia_tao_deploy/config/visual_changenet/default_config.py
+++ b/nvidia_tao_deploy/config/visual_changenet/default_config.py
@@ -130,7 +130,8 @@ class BackboneConfig:
         display_name="Backbone architectures",
         valid_options=(
             "fan_tiny_8_p4_hybrid,fan_small_12_p4_hybrid,"
-            "fan_base_16_p4_hybrid,fan_large_16_p4_hybrid,vit_large_nvdinov2"
+            "fan_base_16_p4_hybrid,fan_large_16_p4_hybrid,vit_large_nvdinov2,"
+            "vit_small_dinov3,vit_small_plus_dinov3,vit_base_dinov3,vit_large_dinov3,vit_huge_plus_dinov3"
         )
     )
     feat_downsample: bool = BOOL_FIELD(
@@ -204,6 +205,13 @@ class CNModelConfig:
     backbone: BackboneConfig = DATACLASS_FIELD(BackboneConfig())
     decode_head: ChangeNetHeadConfig = DATACLASS_FIELD(ChangeNetHeadConfig())
     classify: CNModelClassifyConfig = DATACLASS_FIELD(CNModelClassifyConfig())
+    precise_msda: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="precise MSDeformAttn",
+        description="Schema-compat mirror of the training config's deterministic MSDeformAttn "
+                    "backward flag (C-RADIO / ViT-Adapter backbones). Training-only; ignored at inference/TRT."
+    )
 
 
 @dataclass

--- a/nvidia_tao_deploy/cv/common/telemetry/nvml_utils.py
+++ b/nvidia_tao_deploy/cv/common/telemetry/nvml_utils.py
@@ -6,6 +6,14 @@
 import json
 import pynvml
 
+
+def _as_str(value):
+    """Normalize NVML string values that may be bytes (old pynvml) or str (new pynvml)."""
+    if isinstance(value, (bytes, bytearray)):
+        return value.decode()
+    return value
+
+
 BRAND_NAMES = {
     pynvml.NVML_BRAND_UNKNOWN: "Unknown",
     pynvml.NVML_BRAND_QUADRO: "Quadro",
@@ -60,8 +68,8 @@ class GPUDevice:
         """
         assert self.defined, "Device wasn't defined."
         config_dict = {}
-        config_dict["name"] = self.name.decode().replace(" ", "-")
-        config_dict["pci_bus_id"] = self.pci_bus_id
+        config_dict["name"] = _as_str(self.name).replace(" ", "-")
+        config_dict["pci_bus_id"] = _as_str(self.pci_bus_id)
         config_dict["brand"] = self.brand
         config_dict["memory"] = self.memory
         config_dict["cuda_compute_capability"] = self.cuda_compute_capability

--- a/nvidia_tao_deploy/multimodal/clip/specs/experiment_spec.yaml
+++ b/nvidia_tao_deploy/multimodal/clip/specs/experiment_spec.yaml
@@ -31,6 +31,7 @@ dataset:
       caption_dir: ???            # Directory containing caption .txt files
       caption_file_suffix: .txt
       image_list_file: null       # Optional: text file listing image filenames
+      attribute_pairs_file: null  # Optional: split-aligned PAS pairs metadata
     batch_size: 16
     num_workers: 8
 


### PR DESCRIPTION
## Release 7.1.0

Faithful sync of the private GitLab `release/7.1.0` (source commit `680bb40`) into the public repo.

### What this branch/tag is
`release/7.1.0` and the `7.1.0` tag mirror the **actually released, GitLab-built source**. The public-only patches — the telemetry `ImportError` guard and the `Dockerfile.release` build change (`setup.py bdist_wheel`, no pyarmor) — are **intentionally not on this branch**, so the tag accurately represents what ships.

### Telemetry + Dockerfile handling on merge to main
This branch is cut from the pre-telemetry base, so its delta (10 config files) is **disjoint** from main's telemetry/Dockerfile changes. Merging to main therefore keeps the telemetry guard and Dockerfile.release fix on main automatically, while bringing in the 7.1.0 source updates.

### Contents
- 10 config/source files updated to 7.1.0 (all byte-identical to GitLab `release/7.1.0`)
- Internal-only files (tests/, ci/, .gitlab/, pyarmor, Jenkinsfiles) excluded per the sync policy
- SECURITY.md present