### PR TITLE
Migrate test suite + dev files (full GitHub migration)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.gz filter=lfs diff=lfs merge=lfs -text
+*.tlt filter=lfs diff=lfs merge=lfs -text
+*.tar.gz filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text

--- a/coveragerc
+++ b/coveragerc
@@ -1,0 +1,11 @@
+[run]
+parallel = True
+source=
+## tao-pytorch
+    /usr/local/lib/python3.12/dist-packages/nvidia_tao_pytorch
+## tao-deploy
+    /usr/local/lib/python3.12/dist-packages/nvidia_tao_deploy
+## tao-dataservices
+    /usr/local/lib/python3.12/dist-packages/nvidia_tao_ds
+## tf2
+    /usr/local/lib/python3.12/dist-packages/nvidia_tao_tf2

--- a/tests/clip/test_config.py
+++ b/tests/clip/test_config.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLIP configuration unit tests."""
+
+from pathlib import Path
+
+from omegaconf import OmegaConf
+
+from nvidia_tao_deploy.config.multimodal.clip.default_config import (
+    CLIPExperimentConfig,
+    CLIPValDataConfig,
+)
+
+
+def test_attribute_pairs_file_structured_config():
+    """CLIP dataset items preserve attribute_pairs_file through OmegaConf."""
+    config = OmegaConf.structured(CLIPValDataConfig())
+    config = OmegaConf.merge(
+        config,
+        {
+            "datasets": [
+                {
+                    "image_dir": "/data/images",
+                    "attribute_pairs_file": "/data/test_pairs.json",
+                }
+            ]
+        },
+    )
+
+    serialized = OmegaConf.to_container(config, resolve=True)
+
+    assert serialized["datasets"][0]["attribute_pairs_file"] == "/data/test_pairs.json"
+
+
+def test_default_spec_accepts_attribute_pairs_file():
+    """CLIP default spec preserves the optional PAS pairs path."""
+    spec_path = Path(__file__).parents[2].joinpath(
+        "nvidia_tao_deploy",
+        "multimodal",
+        "clip",
+        "specs",
+        "experiment_spec.yaml",
+    )
+    spec = OmegaConf.load(spec_path)
+    config = OmegaConf.merge(
+        OmegaConf.structured(CLIPExperimentConfig()),
+        spec,
+    )
+
+    assert config.dataset.val.datasets[0].attribute_pairs_file is None

--- a/tests/core/test_backbone_schema_drift.py
+++ b/tests/core/test_backbone_schema_drift.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Drift guard for DINOv3 backbone options in tao-deploy downstream configs (bug 6465432).
+
+DINOv3 backbones are registered as selectable backbones for the segformer and
+visual_changenet tasks (nvidia_tao_pytorch/config/{segformer,visual_changenet}/
+default_config.py list them in the backbone ``type`` valid_options). The
+tao-deploy mirror of those configs stopped at the nvdinov2 backbones, so the
+deploy-side gen_trt_engine spec rejected a DINOv3-backboned model. This guards
+against that mirror falling behind again.
+"""
+from dataclasses import fields
+
+import pytest
+
+from nvidia_tao_deploy.config.segformer.default_config import (
+    BackboneConfig as SegformerBackboneConfig,
+)
+from nvidia_tao_deploy.config.visual_changenet.default_config import (
+    BackboneConfig as ChangeNetBackboneConfig,
+)
+
+# The DINOv3 backbones registered for dense downstream tasks (segformer /
+# visual_changenet) in tao-pytorch. 7B is intentionally excluded - it is not a
+# registered downstream backbone.
+DINOV3_DOWNSTREAM_BACKBONES = [
+    "vit_small_dinov3",
+    "vit_small_plus_dinov3",
+    "vit_base_dinov3",
+    "vit_large_dinov3",
+    "vit_huge_plus_dinov3",
+]
+
+
+def _backbone_type_options(backbone_config_cls):
+    """Return the backbone ``type`` field's valid_options as a list of strings."""
+    (type_field,) = [f for f in fields(backbone_config_cls) if f.name == "type"]
+    return type_field.metadata["valid_options"].split(",")
+
+
+@pytest.mark.core
+@pytest.mark.parametrize(
+    "backbone_config_cls",
+    [SegformerBackboneConfig, ChangeNetBackboneConfig],
+    ids=["segformer", "visual_changenet"],
+)
+def test_dinov3_backbones_present(backbone_config_cls):
+    options = _backbone_type_options(backbone_config_cls)
+    missing = [b for b in DINOV3_DOWNSTREAM_BACKBONES if b not in options]
+    assert not missing, f"deploy backbone enum missing DINOv3 options: {missing}"

--- a/tests/core/test_common_config.py
+++ b/tests/core/test_common_config.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for configuration shared by TAO Deploy models."""
+
+from nvidia_tao_deploy.config.common.common_config import CheckpointerConfig, TrainConfig
+
+
+def test_replace_periodic_checkpointing_is_disabled_by_default():
+    """Keep the deploy schema aligned with the opt-in PyTorch setting."""
+    config = TrainConfig().checkpointer
+    field = type(config).__dataclass_fields__["replace_periodic"]
+
+    assert isinstance(config, CheckpointerConfig)
+    assert config.enable_topk is False
+    assert config.replace_periodic is False
+    assert field.metadata["default_value"] is False
+    assert field.metadata["value_type"] == "bool"

--- a/tests/core/test_nvml_utils.py
+++ b/tests/core/test_nvml_utils.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the NVML telemetry utilities."""
+
+import json
+
+import pynvml
+import pytest
+
+from nvidia_tao_deploy.cv.common.telemetry.nvml_utils import GPUDevice
+
+DEVICE_NAME = "NVIDIA A100-SXM4-80GB"
+EXPECTED_CONFIG_NAME = "NVIDIA-A100-SXM4-80GB"
+
+
+def _make_device(device_name, pci_bus_id="00000000:07:00.0"):
+    return GPUDevice(
+        pci_bus_id=pci_bus_id,
+        device_name=device_name,
+        device_brand=pynvml.NVML_BRAND_NVIDIA,
+        memory=85899345920,
+        cuda_compute_capability=(8, 0),
+    )
+
+
+@pytest.mark.core
+@pytest.mark.parametrize(
+    "device_name",
+    [DEVICE_NAME.encode(), DEVICE_NAME],
+    ids=["bytes_name", "str_name"],
+)
+def test_get_config_name(device_name):
+    """get_config() must handle both bytes (old pynvml) and str (new pynvml) names."""
+    device = _make_device(device_name)
+    config = device.get_config()
+    assert config["name"] == EXPECTED_CONFIG_NAME
+
+
+@pytest.mark.core
+@pytest.mark.parametrize(
+    "device_name",
+    [DEVICE_NAME.encode(), DEVICE_NAME],
+    ids=["bytes_name", "str_name"],
+)
+@pytest.mark.parametrize(
+    "pci_bus_id",
+    [b"00000000:07:00.0", "00000000:07:00.0"],
+    ids=["bytes_bus_id", "str_bus_id"],
+)
+def test_config_is_json_serializable(device_name, pci_bus_id):
+    """No bytes may leak into the config dict: str(device) json.dumps the config."""
+    device = _make_device(device_name, pci_bus_id=pci_bus_id)
+    config = device.get_config()
+    assert json.dumps(config)
+    assert str(device)
+    assert config["pci_bus_id"] == "00000000:07:00.0"


### PR DESCRIPTION
Brings the excluded `tests/` suite and dev config files public from GitLab `release/7.1.0`, as part of migrating everything (minus CI) to GitHub.

- Adds 4 new test files (tests were already present and identical for common files)
- Adds `.gitattributes`, `coveragerc`
- **Not** included: CI (`ci/`, `.gitlab*`, Jenkinsfiles, renovate, sonar), pyarmor, submodules/`third_party`/`tools`, and public-specific `.pylintrc`/`.pre-commit-config.yaml` (kept as-is on main)
- Source/entrypoints untouched → telemetry guard intact