### PR TITLE
build: add tao-core submodule (pinned to latest main)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "tao-core"]
+	path = tao-core
+	url = https://github.com/NVIDIA-TAO/tao-core.git
+	branch = main


### PR DESCRIPTION
Adds `tao-core` as a git submodule at `tao-core/`, tracking `main` and pinned to the current main tip (`825f2140`), using the public GitHub URL. Establishes the submodule pattern for OSS (deploy first; pyt/ds to follow).

**CI impact (verified against the Jenkins shared lib):** the checkout uses `doGenerateSubmoduleConfigurations: false` (no recursion) and `cloneGithubSource` does `rm -rf tao-core && git clone --depth 1 --branch main …`. So this PR is **safe** (the manual clone wipes + replaces the placeholder), but the pipeline **still uses latest main**, not the pinned SHA. Running `/build` to confirm nothing breaks.