### PR TITLE
[TAO-0000][Chore] Add experimental decorator to tao-deploy

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,5 +1,6 @@
 absl-py==2.4.0
 apispec==6.10.0
+colorama
 apispec-webframeworks==1.2.0
 cupy-cuda13x==14.0.1
 flake8==7.3.0
@@ -38,6 +39,7 @@ scikit-image==0.26.0
 scikit-learn==1.8.0
 seaborn==0.13.2
 shapely==2.1.2
+termcolor
 transformers==5.6.2
 
 # Security: upgrade vulnerable packages inherited from the base image (nvcr.io/nvidia/tensorrt:26.03-py3)

--- a/nvidia_tao_deploy/cv/common/decorators.py
+++ b/nvidia_tao_deploy/cv/common/decorators.py
@@ -6,6 +6,10 @@
 from functools import wraps
 import inspect
 import os
+import warnings
+
+from colorama import init
+from termcolor import colored
 # Import Hydra exception classes for config error handling
 try:
     from hydra.errors import ConfigCompositionException, MissingConfigException, HydraException
@@ -33,6 +37,58 @@ try:
     from marshmallow.exceptions import ValidationError as MarshmallowValidationError
 except ImportError:
     MarshmallowValidationError = Exception
+
+
+def experimental(reason):
+    """
+    This is a decorator which can be used to mark functions
+    as experimental. It will result in a warning being emitted
+    when the function is used.
+    """
+    init()
+    if isinstance(reason, str):
+        def decorator(func1):
+
+            fmt1 = colored("Call to experimental function {name} ({reason}).", 'white', 'on_yellow')
+            if inspect.isclass(func1):
+                fmt1 = colored("Call to experimental class {name} ({reason}).", 'white', 'on_yellow')
+
+            @wraps(func1)
+            def new_func1(*args, **kwargs):
+                warnings.simplefilter('always', UserWarning)
+                warnings.warn(
+                    fmt1.format(name=func1.__name__, reason=reason),
+                    category=UserWarning,
+                    stacklevel=2
+                )
+                warnings.simplefilter('default', UserWarning)
+                return func1(*args, **kwargs)
+
+            return new_func1
+
+        return decorator
+
+    if inspect.isclass(reason) or inspect.isfunction(reason):
+        func2 = reason
+
+        fmt2 = colored("Call to experimental function {name}.", 'white', 'on_yellow')
+        if inspect.isclass(func2):
+            fmt2 = colored("Call to experimental class {name}.", 'white', 'on_yellow')
+
+        @wraps(func2)
+        def new_func2(*args, **kwargs):
+            warnings.simplefilter('always', UserWarning)
+            warnings.warn(
+                fmt2.format(name=func2.__name__),
+                category=UserWarning,
+                stacklevel=2
+            )
+            warnings.simplefilter('default', UserWarning)
+            return func2(*args, **kwargs)
+
+        return new_func2
+
+    raise TypeError(repr(type(reason)))
 
 
 def monitor_status(name='module name', mode='gen_trt_engine', hydra=True):


### PR DESCRIPTION
### What changes are proposed in this pull request?

Adds the `experimental` decorator to `nvidia_tao_deploy/cv/common/decorators.py` (alongside `monitor_status`, `override`, `subclass`), matching the existing implementation in `tao-pytorch/nvidia_tao_pytorch/core/decorators/experimental.py`.

```python
from nvidia_tao_deploy.cv.common.decorators import experimental

@experimental("This feature is under active development")
def my_new_function():
    ...

@experimental
class MyExperimentalClass:
    ...
```

### Why are the changes needed?

Parity with tao-pytorch: deploy-side experimental APIs should carry the same yellow-highlighted `UserWarning` so users know they are invoking an experimental surface.

### Related issues

N/A

### Does this PR introduce _any_ user-facing change?

Yes — decorated APIs now emit a `UserWarning` when invoked; no existing behavior changes.

### How was this patch tested?

Verified the decorator emits the expected warning for both function and class usage, mirroring the tao-pytorch implementation and its existing coverage. No new tests added — the implementation is copied verbatim from the already-tested tao-pytorch version.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code

### Release note

```release-note
Added an experimental decorator that warns users when invoking experimental tao-deploy APIs.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [ ] I added or updated tests covering this change
- [x] All tests pass locally
- [x] I added or updated documentation (README, docstrings, docs pages, examples)
- [ ] I updated the version, changelog, or migration notes if this change requires it
- [ ] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

Originally targeted `release/7.1.0` on GitLab; rebased and retargeted to `main` during the GitHub migration. Adds colorama/termcolor deps — check they're in the deploy container requirements.

---
_Migrated from GitLab MR nvidia-tao-toolkit/tao-deploy!209, rebased onto GitHub `main`._