### PR TITLE
[TAO-1796][Feature] video_clip: add InternVideo2-CLIP TensorRT deploy module

### DIFF
--- a/docs/supported_commands.md
+++ b/docs/supported_commands.md
@@ -41,6 +41,7 @@ _Source: `setup.py` console scripts plus each implementation's `scripts/` packag
 | `segformer` | cv | `nvidia_tao_deploy.cv.segformer` | evaluate, gen_trt_engine, inference, default_specs |
 | `ssd` | cv | `nvidia_tao_deploy.cv.ssd` | evaluate, gen_trt_engine, inference |
 | `unet` | cv | `nvidia_tao_deploy.cv.unet` | evaluate, gen_trt_engine, inference |
+| `video_clip` | multimodal | `nvidia_tao_deploy.multimodal.video_clip` | evaluate, gen_trt_engine, inference, default_specs |
 | `visual_changenet` | cv | `nvidia_tao_deploy.cv.visual_changenet` | evaluate, gen_trt_engine, inference, default_specs |
 | `yolo_v3` | cv | `nvidia_tao_deploy.cv.yolo_v3` | evaluate, gen_trt_engine, inference |
 | `yolo_v4` | cv | `nvidia_tao_deploy.cv.yolo_v4` | evaluate, gen_trt_engine, inference |

--- a/nvidia_tao_deploy/config/multimodal/video_clip/__init__.py
+++ b/nvidia_tao_deploy/config/multimodal/video_clip/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP deploy configuration."""

--- a/nvidia_tao_deploy/config/multimodal/video_clip/default_config.py
+++ b/nvidia_tao_deploy/config/multimodal/video_clip/default_config.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP (InternVideo2-CLIP) deploy experiment configuration."""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+from omegaconf import MISSING
+
+from nvidia_tao_deploy.config.common.common_config import (
+    CommonExperimentConfig,
+    GenTrtEngineConfig,
+    TrtConfig,
+)
+from nvidia_tao_deploy.config.utils.types import (
+    BOOL_FIELD,
+    DATACLASS_FIELD,
+    INT_FIELD,
+    LIST_FIELD,
+    STR_FIELD,
+)
+
+
+# =============================================================================
+# Model Config
+# =============================================================================
+@dataclass
+class VideoCLIPModelConfig:
+    """Video-CLIP model configuration (subset needed for deploy preprocessing)."""
+
+    type: str = STR_FIELD(
+        value="internvideo2-clip-l14",
+        default_value="internvideo2-clip-l14",
+        description="Video-CLIP model type.",
+        display_name="Model Type",
+    )
+    image_size: int = INT_FIELD(
+        value=224,
+        default_value=224,
+        description="Square input resolution H=W for the vision tower. "
+                    "Overridden by the engine's image input shape at runtime.",
+        display_name="Image Size",
+    )
+    canonicalize_text: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        description="Apply lowercase + punctuation-removal before tokenization. "
+                    "Kept False for retrieval (matches training).",
+        display_name="Canonicalize Text",
+    )
+
+
+# =============================================================================
+# Dataset Config
+# =============================================================================
+@dataclass
+class VideoCLIPEvalDataConfig:
+    """Validation data for multi-relevance text->video retrieval eval."""
+
+    gt_queries: str = STR_FIELD(
+        value=MISSING,
+        default_value=MISSING,
+        description="Explicit-relevance eval file (e.g. domain_test_*.json) with "
+                    "'gallery' and 'queries' (each query: text, chunk_id, slice, "
+                    "relevant_clip_ids).",
+        display_name="Ground-truth Queries",
+    )
+    metadata: str = STR_FIELD(
+        value=MISSING,
+        default_value=MISSING,
+        description="vadr1_chunks metadata JSON used to resolve each gallery "
+                    "chunk_id to its video path and time window.",
+        display_name="Chunk Metadata",
+    )
+    video_root: Optional[str] = STR_FIELD(
+        value=None,
+        default_value=None,
+        description="Optional root prepended to relative video paths.",
+        display_name="Video Root",
+    )
+    path_prefix_mapping: Dict[str, str] = field(default_factory=dict)
+    batch_size: int = INT_FIELD(
+        value=8,
+        default_value=8,
+        valid_min=1,
+        description="Clips per batch when embedding the gallery.",
+        display_name="Batch Size",
+    )
+    num_workers: int = INT_FIELD(
+        value=8,
+        default_value=8,
+        valid_min=0,
+        description="Reserved (single-process decord loading is used).",
+        display_name="Number of Workers",
+    )
+
+
+@dataclass
+class VideoCLIPDatasetConfig:
+    """Dataset configuration for Video-CLIP deploy evaluation."""
+
+    val: VideoCLIPEvalDataConfig = DATACLASS_FIELD(
+        VideoCLIPEvalDataConfig(),
+        description="Validation/retrieval dataset configuration.",
+    )
+
+
+# =============================================================================
+# Inference / Eval Config
+# =============================================================================
+@dataclass
+class VideoCLIPInferenceEvalConfig:
+    """Configuration for Video-CLIP TRT inference and evaluation."""
+
+    trt_engine: Optional[str] = STR_FIELD(
+        value=None,
+        default_value=None,
+        description="Path to the combined TensorRT engine.",
+        display_name="TRT Engine Path",
+    )
+    batch_size: int = INT_FIELD(
+        value=8,
+        default_value=8,
+        valid_min=1,
+        description="Batch size for embedding extraction.",
+        display_name="Batch Size",
+    )
+    results_dir: Optional[str] = STR_FIELD(
+        value=None,
+        default_value=None,
+        description="Directory to save results.",
+        display_name="Results Directory",
+    )
+    text_file: Optional[str] = STR_FIELD(
+        value=None,
+        default_value=None,
+        description="Optional text file (one prompt per line) for text-embedding "
+                    "inference.",
+        display_name="Text File",
+    )
+    num_gpus: int = INT_FIELD(
+        value=1,
+        default_value=1,
+        valid_min=1,
+        description="Number of GPUs (TRT eval runs on a single device).",
+        display_name="Number of GPUs",
+    )
+    gpu_ids: List[int] = LIST_FIELD(
+        arrList=[0],
+        default_value=[0],
+        description="GPU device IDs.",
+        display_name="GPU IDs",
+    )
+
+
+# =============================================================================
+# TRT Engine Config
+# =============================================================================
+@dataclass
+class VideoCLIPTrtConfig(TrtConfig):
+    """Video-CLIP TensorRT configuration."""
+
+    data_type: str = STR_FIELD(
+        value="fp32",
+        default_value="fp32",
+        valid_options="fp32,fp16",
+        description="TensorRT precision: FP32 or FP16. FP16 automatically "
+                    "keeps numerically sensitive InternVideo2 vision block "
+                    "normalization reductions in FP32.",
+        display_name="Data Type",
+    )
+    strongly_typed: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        description="Build a strongly-typed TensorRT engine that honors the "
+                    "explicit precision of a mixed-precision ONNX (e.g. from "
+                    "ModelOpt AutoCast, which keeps the vision RMSNorm in FP32). "
+                    "Required for a pin-free FP16 engine: a weakly-typed FP16 "
+                    "build re-lowers the RMSNorm reduction and collapses accuracy. "
+                    "Use with data_type=fp32 (graph carries the precision).",
+        display_name="Strongly Typed",
+    )
+    max_batch_size: int = INT_FIELD(
+        value=16,
+        default_value=16,
+        valid_min=1,
+        description="Maximum batch size in the TRT optimization profile.",
+        display_name="Maximum batch size",
+    )
+
+
+@dataclass
+class VideoCLIPGenTrtEngineConfig(GenTrtEngineConfig):
+    """Video-CLIP TRT engine generation config."""
+
+    tensorrt: VideoCLIPTrtConfig = DATACLASS_FIELD(VideoCLIPTrtConfig())
+
+
+# =============================================================================
+# Experiment Config
+# =============================================================================
+@dataclass
+class VideoCLIPExperimentConfig(CommonExperimentConfig):
+    """Video-CLIP deploy experiment config."""
+
+    model_name: Optional[str] = STR_FIELD(
+        value="video_clip",
+        default_value="video_clip",
+        description="Name of model for task invocation.",
+        display_name="Model Name",
+    )
+    model: VideoCLIPModelConfig = DATACLASS_FIELD(
+        VideoCLIPModelConfig(),
+        description="Model config.",
+    )
+    dataset: VideoCLIPDatasetConfig = DATACLASS_FIELD(
+        VideoCLIPDatasetConfig(),
+        description="Dataset config.",
+    )
+    evaluate: VideoCLIPInferenceEvalConfig = DATACLASS_FIELD(
+        VideoCLIPInferenceEvalConfig(),
+        description="Evaluation config.",
+    )
+    inference: VideoCLIPInferenceEvalConfig = DATACLASS_FIELD(
+        VideoCLIPInferenceEvalConfig(),
+        description="Inference config.",
+    )
+    gen_trt_engine: VideoCLIPGenTrtEngineConfig = DATACLASS_FIELD(
+        VideoCLIPGenTrtEngineConfig(),
+        description="TensorRT engine generation config.",
+    )

--- a/nvidia_tao_deploy/config/multimodal/video_clip/default_config.py
+++ b/nvidia_tao_deploy/config/multimodal/video_clip/default_config.py
@@ -3,7 +3,7 @@
 
 """Video-CLIP (InternVideo2-CLIP) deploy experiment configuration."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Optional
 from omegaconf import MISSING
 
@@ -15,6 +15,7 @@ from nvidia_tao_deploy.config.common.common_config import (
 from nvidia_tao_deploy.config.utils.types import (
     BOOL_FIELD,
     DATACLASS_FIELD,
+    DICT_FIELD,
     INT_FIELD,
     LIST_FIELD,
     STR_FIELD,
@@ -78,7 +79,12 @@ class VideoCLIPEvalDataConfig:
         description="Optional root prepended to relative video paths.",
         display_name="Video Root",
     )
-    path_prefix_mapping: Dict[str, str] = field(default_factory=dict)
+    path_prefix_mapping: Dict[str, str] = DICT_FIELD(
+        {},
+        description="Optional mapping from original path prefixes to local "
+                    "prefixes, applied before video_root.",
+        display_name="Path Prefix Mapping",
+    )
     batch_size: int = INT_FIELD(
         value=8,
         default_value=8,

--- a/nvidia_tao_deploy/engine/builder.py
+++ b/nvidia_tao_deploy/engine/builder.py
@@ -134,6 +134,14 @@ class EngineBuilder(ABC):
                 faster_dynamic_shapes = False
             self.config.set_preview_feature(trt.PreviewFeature.FASTER_DYNAMIC_SHAPES_0805, faster_dynamic_shapes)
 
+    def _extra_network_flags(self):
+        """Extra NetworkDefinitionCreationFlag bits OR-ed into create_network.
+
+        Base returns 0; subclasses may override (e.g. to request a strongly-typed
+        network for a mixed-precision ONNX).
+        """
+        return 0
+
     def create_network(self, model_path, file_format="onnx"):
         """Parse the UFF/ONNX graph and create the corresponding TensorRT network definition.
 
@@ -145,6 +153,7 @@ class EngineBuilder(ABC):
             network_flags = 1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
             if TRT_8_API:
                 network_flags = network_flags | (1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_PRECISION))
+            network_flags |= self._extra_network_flags()
 
             self.network = self.builder.create_network(network_flags)
             self.parser = trt.OnnxParser(self.network, self.trt_logger)

--- a/nvidia_tao_deploy/multimodal/video_clip/__init__.py
+++ b/nvidia_tao_deploy/multimodal/video_clip/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP (InternVideo2-CLIP) TensorRT deployment module."""

--- a/nvidia_tao_deploy/multimodal/video_clip/dataloader.py
+++ b/nvidia_tao_deploy/multimodal/video_clip/dataloader.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP dataloader for TensorRT retrieval evaluation.
+
+The frame sampling (decord + uniform ``linspace`` over the chunk's time window),
+the resolution logic, and the frame preprocessing (Resize 224 BICUBIC ->
+ToTensor -> ImageNet Normalize) are ported 1:1 from the tao-pytorch trainer
+(``dataloader/video_text_loader.py`` + ``model/adapters/internvideo2clip.py``)
+so serving preprocessing is byte-identical to training. Do not "improve" the
+resize / normalization / channel order here — that is a silent-accuracy contract.
+"""
+
+import json
+import logging
+import string
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import numpy as np
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+_TRANS_PUNCTUATION = str.maketrans("", "", string.punctuation)
+
+
+def canonicalize_text(text: str) -> str:
+    """Lowercase + strip punctuation (big_vision/SigLIP canonicalization).
+
+    Applied to query text before tokenization only when the exported model
+    config has ``canonicalize_text: true`` — must match the training-time
+    setting or the tokens (and thus the embeddings) diverge. Mirrors the image
+    ``clip`` deploy module's ``canonicalize_text``.
+    """
+    text = text.replace("_", " ").translate(_TRANS_PUNCTUATION).lower()
+    return " ".join(text.split()).strip()
+
+
+# InternVideo2-CLIP L14 frame normalization (ImageNet stats, NOT CLIP stats).
+IMAGENET_MEAN = np.array((0.485, 0.456, 0.406), dtype=np.float32)
+IMAGENET_STD = np.array((0.229, 0.224, 0.225), dtype=np.float32)
+
+
+def _resolve_video_path(video_path, data_root=None, path_prefix_mapping=None):
+    """Resolve original dataset paths to local paths (verbatim from trainer)."""
+    if video_path is None:
+        return ""
+    video_path = str(video_path)
+    mapping = path_prefix_mapping or {}
+
+    for prefix, replacement in mapping.items():
+        if prefix and video_path.startswith(prefix):
+            return video_path.replace(prefix, str(replacement), 1)
+
+    path = Path(video_path)
+    if path.is_absolute():
+        if data_root and video_path.startswith("/media/wbf/"):
+            return str(Path(data_root) / video_path[len("/media/wbf/"):])
+        return str(path)
+    if data_root:
+        return str(Path(data_root) / path)
+    return video_path
+
+
+def linspace_indices(total_frames: int, num_frames: int) -> np.ndarray:
+    """Select ``num_frames`` frame indices (verbatim from trainer).
+
+    Uniform over ``[0, total_frames-1]`` when there are enough frames, else all
+    frames padded by repeating the last one.
+    """
+    if total_frames <= 0:
+        raise ValueError("Cannot sample from an empty video clip")
+    if total_frames >= num_frames:
+        return np.linspace(0, total_frames - 1, num_frames, dtype=int)
+    indices = np.full((num_frames,), total_frames - 1, dtype=int)
+    indices[:total_frames] = np.arange(total_frames)
+    return indices
+
+
+def load_video_frames(video_path, num_frames, start_time_sec=None,
+                      end_time_sec=None, start_frame=None, end_frame=None):
+    """Load ``num_frames`` PIL RGB frames from a clip via decord (verbatim).
+
+    Mirrors the trainer's decord path: resolve the frame window (by frame range
+    if given, else by time * avg_fps), then uniform-sample ``num_frames`` inside
+    that window.
+    """
+    import decord  # pylint: disable=import-outside-toplevel
+
+    reader = decord.VideoReader(str(video_path))
+    actual_frames = len(reader)
+    start = 0
+    end = actual_frames
+    if start_frame is not None and end_frame is not None:
+        start = max(0, min(int(start_frame), actual_frames - 1))
+        end = min(int(end_frame), actual_frames)
+    elif start_time_sec is not None and end_time_sec is not None:
+        fps = reader.get_avg_fps()
+        start = max(0, min(int(round(float(start_time_sec) * fps)), actual_frames - 1))
+        end = min(int(round(float(end_time_sec) * fps)), actual_frames)
+    if end <= start:
+        raise ValueError(f"Invalid video range for {video_path}: [{start}, {end})")
+    frame_indices = linspace_indices(end - start, num_frames) + start
+    frames = reader.get_batch(frame_indices).asnumpy()
+    return [Image.fromarray(frame).convert("RGB") for frame in frames]
+
+
+def preprocess_frames(frames: List[Image.Image], image_size: int) -> np.ndarray:
+    """Resize (BICUBIC) -> /255 -> ImageNet-normalize -> (T, C, H, W) float32.
+
+    Matches ``InternVideo2FrameTransform``: torchvision Resize((s,s), BICUBIC) on
+    a PIL image is PIL's own BICUBIC resize; ToTensor scales to [0,1] and moves
+    channels first; Normalize subtracts/divides the ImageNet stats.
+    """
+    out = np.empty((len(frames), 3, image_size, image_size), dtype=np.float32)
+    for i, img in enumerate(frames):
+        img = img.resize((image_size, image_size), Image.Resampling.BICUBIC)
+        arr = np.asarray(img, dtype=np.float32) / 255.0          # (H, W, 3), RGB
+        arr = (arr - IMAGENET_MEAN) / IMAGENET_STD
+        out[i] = np.transpose(arr, (2, 0, 1))                    # (3, H, W)
+    return out
+
+
+def build_chunk_index(
+    metadata_path: str,
+    data_root: Optional[str] = None,
+    path_prefix_mapping: Optional[dict] = None,
+) -> Dict[str, dict]:
+    """Map ``sample_id`` -> clip location from a vadr1_chunks metadata file.
+
+    ``sample_id`` is ``f"{dataset}/{video_id}#{chunk_index}"`` — the same id the
+    eval GT uses for gallery ``chunk_id`` / ``relevant_clip_ids``.
+    """
+    with open(metadata_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    # vadr1_chunks is a list of video records, optionally wrapped in {"data": [...]}.
+    if isinstance(data, list):
+        records = data
+    elif isinstance(data, dict) and isinstance(data.get("data"), list):
+        records = data["data"]
+    else:
+        raise ValueError(
+            f"Unrecognized chunk-metadata format in {metadata_path}: expected a "
+            f"list of video records (or {{'data': [...]}}), got {type(data).__name__}."
+        )
+
+    index: Dict[str, dict] = {}
+    for record in records:
+        video_path = _resolve_video_path(
+            record.get("video_path"), data_root=data_root,
+            path_prefix_mapping=path_prefix_mapping,
+        )
+        for chunk in record.get("chunks", []):
+            chunk_index = chunk.get("chunk_index", 0)
+            sample_id = f"{record.get('dataset', '')}/{record.get('video_id', '')}#{chunk_index}"
+            index[sample_id] = {
+                "video_path": video_path,
+                "start_time_sec": chunk.get("start_time_sec"),
+                "end_time_sec": chunk.get("end_time_sec"),
+                "start_frame": chunk.get("start_frame"),
+                "end_frame": chunk.get("end_frame"),
+            }
+    return index
+
+
+class VideoCLIPGalleryLoader:
+    """Batch loader for a fixed, ordered gallery of video chunks.
+
+    Yields ``(videos, chunk_ids)`` where ``videos`` is ``(B, T, C, H, W)`` float32
+    and ``chunk_ids`` preserves gallery order — the row-to-id alignment the
+    evaluator relies on to map ``relevant_clip_ids`` to gallery indices.
+    """
+
+    def __init__(
+        self,
+        chunk_ids: List[str],
+        chunk_index: Dict[str, dict],
+        num_frames: int,
+        image_size: int,
+        batch_size: int = 8,
+        dtype=np.float32,
+    ):
+        """Initialize the gallery loader.
+
+        Args:
+            chunk_ids: Ordered gallery chunk ids (the corpus).
+            chunk_index: sample_id -> clip location (from build_chunk_index).
+            num_frames: Frames per clip T (from the engine).
+            image_size: Square input size H=W (from the engine).
+            batch_size: Clips per batch.
+            dtype: Output numpy dtype for the video tensor.
+        """
+        self.chunk_ids = list(chunk_ids)
+        self.chunk_index = chunk_index
+        self.num_frames = num_frames
+        self.image_size = image_size
+        self.batch_size = batch_size
+        self.dtype = dtype
+
+        missing = [c for c in self.chunk_ids if c not in chunk_index]
+        if missing:
+            raise KeyError(
+                f"{len(missing)} gallery chunk_ids not found in the chunk "
+                f"metadata (e.g. {missing[:3]}). Check dataset.val.metadata / "
+                f"video_root."
+            )
+        self.n_samples = len(self.chunk_ids)
+        self.n_batches = (self.n_samples + batch_size - 1) // batch_size
+
+    def _load_one(self, chunk_id: str) -> np.ndarray:
+        loc = self.chunk_index[chunk_id]
+        frames = load_video_frames(
+            loc["video_path"], self.num_frames,
+            start_time_sec=loc["start_time_sec"], end_time_sec=loc["end_time_sec"],
+            start_frame=loc["start_frame"], end_frame=loc["end_frame"],
+        )
+        return preprocess_frames(frames, self.image_size).astype(self.dtype)
+
+    def __len__(self) -> int:
+        """Number of batches."""
+        return self.n_batches
+
+    def __iter__(self):
+        """Iterate over (videos, chunk_ids) batches in gallery order."""
+        for start in range(0, self.n_samples, self.batch_size):
+            batch_ids = self.chunk_ids[start:start + self.batch_size]
+            videos = np.stack([self._load_one(c) for c in batch_ids], axis=0)
+            yield videos, batch_ids

--- a/nvidia_tao_deploy/multimodal/video_clip/dataloader.py
+++ b/nvidia_tao_deploy/multimodal/video_clip/dataloader.py
@@ -55,8 +55,6 @@ def _resolve_video_path(video_path, data_root=None, path_prefix_mapping=None):
 
     path = Path(video_path)
     if path.is_absolute():
-        if data_root and video_path.startswith("/media/wbf/"):
-            return str(Path(data_root) / video_path[len("/media/wbf/"):])
         return str(path)
     if data_root:
         return str(Path(data_root) / path)

--- a/nvidia_tao_deploy/multimodal/video_clip/engine_builder.py
+++ b/nvidia_tao_deploy/multimodal/video_clip/engine_builder.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP TensorRT engine builder."""
+
+import logging
+
+import tensorrt as trt
+
+from nvidia_tao_deploy.engine.builder import EngineBuilder
+
+logging.basicConfig(
+    format='%(asctime)s [TAO Toolkit] [%(levelname)s] %(name)s %(lineno)d: %(message)s',
+    level="INFO",
+)
+logger = logging.getLogger(__name__)
+
+
+class VideoCLIPEngineBuilder(EngineBuilder):
+    """Parses a Video-CLIP ONNX graph and builds a TensorRT engine from it.
+
+    Video-CLIP's combined ONNX has a 5-D vision input (B, T, C, H, W). The base
+    ``EngineBuilder`` resolves each ONNX input axis independently — static dims
+    pass through and only a dynamic batch axis uses the min/opt/max profile — so
+    the 5-D video input needs no special handling here (the ONNX is exported with
+    dynamic batch + static T/C/H/W).
+    """
+
+    def __init__(self, data_format="channels_first", **kwargs):
+        """Init.
+
+        Args:
+            data_format (str): Input data format.
+        """
+        super().__init__(**kwargs)
+        self._data_format = data_format
+
+    def _extra_network_flags(self):
+        """Request a strongly-typed network for a mixed-precision ONNX.
+
+        TensorRT 10 enables strongly-typed mode via a NETWORK creation flag (not
+        just the builder-config flag the base sets); it is required so an AutoCast
+        mixed-precision ONNX (vision RMSNorm kept FP32) builds as intended.
+        """
+        if self._strongly_typed and hasattr(trt.NetworkDefinitionCreationFlag, "STRONGLY_TYPED"):
+            return 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
+        return 0
+
+    def get_fp16_precision_constraints(self):
+        """Return FP32 constraints for numerically sensitive vision norms."""
+        constraints = {}
+        for layer in self.network:
+            name = layer.name
+            is_vision_block = name.startswith(
+                "/model/vision_encoder/blocks."
+            )
+            is_block_norm = "/norm1/" in name or "/norm2/" in name
+            is_reduction = name.endswith(("/Pow", "/ReduceMean"))
+            if is_vision_block and is_block_norm and is_reduction:
+                constraints[name] = "fp32"
+        return constraints

--- a/nvidia_tao_deploy/multimodal/video_clip/entrypoint/__init__.py
+++ b/nvidia_tao_deploy/multimodal/video_clip/entrypoint/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP entrypoint module."""

--- a/nvidia_tao_deploy/multimodal/video_clip/entrypoint/video_clip.py
+++ b/nvidia_tao_deploy/multimodal/video_clip/entrypoint/video_clip.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TAO Deploy command line wrapper to invoke Video-CLIP CLI scripts."""
+
+import argparse
+from nvidia_tao_deploy.multimodal.video_clip import scripts
+
+from nvidia_tao_deploy.cv.common.entrypoint.entrypoint_hydra import (
+    get_subtasks,
+    launch,
+    command_line_parser,
+)
+
+
+def get_subtask_list():
+    """Return the list of subtasks by inspecting the scripts package."""
+    return get_subtasks(scripts)
+
+
+def main():
+    """Main entrypoint wrapper."""
+    parser = argparse.ArgumentParser(
+        "video_clip",
+        add_help=True,
+        description="Train Adapt Optimize Deploy entrypoint for Video-CLIP",
+    )
+
+    subtasks = get_subtask_list()
+    args, unknown_args = command_line_parser(parser, subtasks)
+    launch(vars(args), unknown_args, subtasks, network="video_clip")
+
+
+if __name__ == '__main__':
+    main()

--- a/nvidia_tao_deploy/multimodal/video_clip/evaluation/__init__.py
+++ b/nvidia_tao_deploy/multimodal/video_clip/evaluation/__init__.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP retrieval evaluation module for TensorRT inference."""
+
+from nvidia_tao_deploy.multimodal.video_clip.evaluation.metrics import (
+    compute_ap,
+    compute_auc,
+    compute_ndcg,
+)
+from nvidia_tao_deploy.multimodal.video_clip.evaluation.retrieval import (
+    RetrievalEvaluator,
+    RetrievalMetrics,
+    evaluate_by_slice,
+    log_retrieval_metrics,
+)
+
+__all__ = [
+    "compute_ap",
+    "compute_auc",
+    "compute_ndcg",
+    "RetrievalEvaluator",
+    "RetrievalMetrics",
+    "evaluate_by_slice",
+    "log_retrieval_metrics",
+]

--- a/nvidia_tao_deploy/multimodal/video_clip/evaluation/metrics.py
+++ b/nvidia_tao_deploy/multimodal/video_clip/evaluation/metrics.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Retrieval metric primitives.
+
+Copied verbatim from the tao-pytorch video_clip trainer
+(``nvidia_tao_pytorch/multimodal/video_clip/model/evaluation/metrics.py``) so the
+deploy-side mAP is computed identically to the reference validation curve.
+"""
+
+import numpy as np
+
+
+def compute_ap(sorted_labels: np.ndarray) -> float:
+    """Compute Average Precision for a single query.
+
+    Args:
+        sorted_labels: Binary relevance labels sorted by descending score.
+
+    Returns:
+        Average Precision score.
+    """
+    n_pos = np.sum(sorted_labels)
+    if n_pos == 0:
+        return 0.0
+
+    hits = 0
+    precision_sum = 0.0
+    for rank, label in enumerate(sorted_labels):
+        if label:
+            hits += 1
+            precision_sum += hits / (rank + 1)
+
+    return precision_sum / n_pos
+
+
+def compute_ndcg(sorted_labels: np.ndarray, k: int) -> float:
+    """Compute NDCG@k for a single query.
+
+    Args:
+        sorted_labels: Binary relevance labels sorted by descending score.
+        k: Number of top results to consider.
+
+    Returns:
+        NDCG@k score.
+    """
+    n_pos = np.sum(sorted_labels)
+    if n_pos == 0:
+        return 0.0
+
+    actual_k = min(k, len(sorted_labels))
+    top_k = sorted_labels[:actual_k]
+    gains = top_k / np.log2(np.arange(2, actual_k + 2))
+    dcg = np.sum(gains)
+
+    ideal_k = min(int(n_pos), actual_k)
+    ideal = np.ones(ideal_k)
+    ideal_gains = ideal / np.log2(np.arange(2, ideal_k + 2))
+    idcg = np.sum(ideal_gains)
+
+    return dcg / idcg if idcg > 0 else 0.0
+
+
+def compute_auc(scores: np.ndarray, labels: np.ndarray) -> float:
+    """Compute AUC (Area Under ROC Curve).
+
+    Args:
+        scores: Similarity/confidence scores.
+        labels: Binary labels (1 for positive, 0 for negative).
+
+    Returns:
+        AUC score.
+    """
+    n_pos = np.sum(labels)
+    n_neg = len(labels) - n_pos
+
+    if n_pos == 0 or n_neg == 0:
+        return 1.0 if n_neg == 0 else 0.0
+
+    sorted_idx = np.argsort(scores)
+    sorted_labels = labels[sorted_idx]
+
+    ranks = np.arange(1, len(labels) + 1, dtype=np.float64)
+    pos_rank_sum = np.sum(ranks[sorted_labels == 1])
+
+    return (pos_rank_sum - n_pos * (n_pos + 1) / 2) / (n_pos * n_neg)

--- a/nvidia_tao_deploy/multimodal/video_clip/evaluation/retrieval.py
+++ b/nvidia_tao_deploy/multimodal/video_clip/evaluation/retrieval.py
@@ -133,7 +133,7 @@ class RetrievalEvaluator:
                 ndcg_scores[k].append(compute_ndcg(sorted_labels, k))
 
             if self._compute_auc:
-                auc_scores.append(compute_auc(sims, sorted_labels))
+                auc_scores.append(compute_auc(sims[sorted_idx], sorted_labels))
 
         return RetrievalMetrics(
             recall_at_k={k: float(np.mean(v)) for k, v in recall_scores.items() if v},

--- a/nvidia_tao_deploy/multimodal/video_clip/evaluation/retrieval.py
+++ b/nvidia_tao_deploy/multimodal/video_clip/evaluation/retrieval.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Multi-relevance text->video retrieval evaluation for Video-CLIP TRT.
+
+Reproduces the tao-pytorch trainer's retrieval evaluator
+(``model/evaluation/retrieval.py``) with a numpy-only similarity path (no torch)
+so the deploy-side headline number matches the reference validation curve. Each
+query carries an explicit ``relevant_clip_ids`` set (verbatim, not derived from
+idx grouping); mAP is the mean of per-query Average Precision over the cosine-
+ranked gallery, with an optional per-slice breakdown.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+from nvidia_tao_deploy.multimodal.video_clip.evaluation.metrics import (
+    compute_ap,
+    compute_auc,
+    compute_ndcg,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RetrievalMetrics:
+    """Container for retrieval evaluation metrics."""
+
+    recall_at_k: Dict[int, float] = field(default_factory=dict)
+    hit_at_k: Dict[int, float] = field(default_factory=dict)
+    map_score: float = 0.0
+    median_rank: float = 0.0
+    mean_rank: float = 0.0
+    ndcg_at_k: Dict[int, float] = field(default_factory=dict)
+    auc: float = 0.0
+    num_queries: int = 0
+    gallery_size: int = 0
+
+    def to_dict(self) -> Dict[str, float]:
+        """Convert metrics to a flat dictionary."""
+        result = {
+            'mAP': self.map_score,
+            'median_rank': self.median_rank,
+            'mean_rank': self.mean_rank,
+            'auc': self.auc,
+            'num_queries': self.num_queries,
+            'gallery_size': self.gallery_size,
+        }
+        for k, v in self.recall_at_k.items():
+            result[f'recall@{k}'] = v
+        for k, v in self.hit_at_k.items():
+            result[f'hit@{k}'] = v
+        for k, v in self.ndcg_at_k.items():
+            result[f'ndcg@{k}'] = v
+        return result
+
+
+def _l2_normalize(x: np.ndarray) -> np.ndarray:
+    """Row-wise L2 normalization (matches the trainer's F.normalize)."""
+    return x / (np.linalg.norm(x, axis=1, keepdims=True) + 1e-12)
+
+
+class RetrievalEvaluator:
+    """Text->video retrieval evaluator (numpy).
+
+    Args:
+        k_values: Tuple of k values for Recall@k / Hit@k / NDCG@k.
+        compute_auc: Whether to compute AUC.
+    """
+
+    def __init__(self, k_values: Tuple[int, ...] = (1, 5, 10),
+                 compute_auc: bool = True):
+        """Initialize the retrieval evaluator."""
+        self.k_values = k_values
+        self._compute_auc = compute_auc
+
+    def evaluate(
+        self,
+        query_embs: np.ndarray,
+        gallery_embs: np.ndarray,
+        ground_truth: List[List[int]],
+    ) -> RetrievalMetrics:
+        """Compute retrieval metrics.
+
+        Args:
+            query_embs: Query embeddings (N, D).
+            gallery_embs: Gallery embeddings (M, D).
+            ground_truth: ``gt[i]`` = list of relevant gallery indices for query i.
+
+        Returns:
+            RetrievalMetrics.
+        """
+        query_embs = _l2_normalize(np.asarray(query_embs, dtype=np.float32))
+        gallery_embs = _l2_normalize(np.asarray(gallery_embs, dtype=np.float32))
+        n_queries = query_embs.shape[0]
+        n_gallery = gallery_embs.shape[0]
+
+        similarity_matrix = query_embs @ gallery_embs.T
+
+        ap_scores: List[float] = []
+        ranks: List[int] = []
+        recall_scores = {k: [] for k in self.k_values}
+        hit_scores = {k: [] for k in self.k_values}
+        ndcg_scores = {k: [] for k in self.k_values}
+        auc_scores: List[float] = []
+
+        for i in range(n_queries):
+            sims = similarity_matrix[i]
+            relevant_indices = set(ground_truth[i])
+            n_pos = len(relevant_indices)
+            if n_pos == 0:
+                continue
+
+            sorted_idx = np.argsort(-sims)
+            sorted_labels = np.array(
+                [1.0 if idx in relevant_indices else 0.0 for idx in sorted_idx]
+            )
+
+            ap_scores.append(compute_ap(sorted_labels))
+
+            first_pos_rank = np.where(sorted_labels == 1)[0]
+            if len(first_pos_rank) > 0:
+                ranks.append(first_pos_rank[0] + 1)
+
+            for k in self.k_values:
+                hits_at_k = np.sum(sorted_labels[:k])
+                recall_scores[k].append(hits_at_k / n_pos)
+                hit_scores[k].append(1.0 if hits_at_k > 0 else 0.0)
+                ndcg_scores[k].append(compute_ndcg(sorted_labels, k))
+
+            if self._compute_auc:
+                auc_scores.append(compute_auc(sims, sorted_labels))
+
+        return RetrievalMetrics(
+            recall_at_k={k: float(np.mean(v)) for k, v in recall_scores.items() if v},
+            hit_at_k={k: float(np.mean(v)) for k, v in hit_scores.items() if v},
+            map_score=float(np.mean(ap_scores)) if ap_scores else 0.0,
+            median_rank=float(np.median(ranks)) if ranks else 0.0,
+            mean_rank=float(np.mean(ranks)) if ranks else 0.0,
+            ndcg_at_k={k: float(np.mean(v)) for k, v in ndcg_scores.items() if v},
+            auc=float(np.mean(auc_scores)) if auc_scores else 0.0,
+            num_queries=len(ap_scores),
+            gallery_size=n_gallery,
+        )
+
+
+def evaluate_by_slice(
+    evaluator: RetrievalEvaluator,
+    query_embs: np.ndarray,
+    gallery_embs: np.ndarray,
+    ground_truth: List[List[int]],
+    slices: List[str],
+) -> Dict[str, RetrievalMetrics]:
+    """Compute overall metrics plus one RetrievalMetrics per slice.
+
+    Args:
+        evaluator: A RetrievalEvaluator.
+        query_embs: (N, D) query embeddings.
+        gallery_embs: (M, D) gallery embeddings.
+        ground_truth: Per-query relevant gallery-index lists.
+        slices: Per-query slice label (same length/order as query_embs).
+
+    Returns:
+        Dict mapping 'overall' and each slice name to RetrievalMetrics.
+    """
+    results = {'overall': evaluator.evaluate(query_embs, gallery_embs, ground_truth)}
+    for name in sorted(set(slices)):
+        idx = [i for i, s in enumerate(slices) if s == name]
+        results[name] = evaluator.evaluate(
+            query_embs[idx], gallery_embs, [ground_truth[i] for i in idx]
+        )
+    return results
+
+
+def log_retrieval_metrics(results: Dict[str, RetrievalMetrics], prefix: str = "") -> None:
+    """Log a compact table of retrieval metrics per slice."""
+    header = f"{prefix}Retrieval metrics (slice: mAP / R@1 / R@5 / R@10 / nDCG@10 / n):"
+    lines = [header]
+    for name, m in results.items():
+        lines.append(
+            f"  {name:<20} "
+            f"mAP={m.map_score:.4f} "
+            f"R@1={m.recall_at_k.get(1, 0):.4f} "
+            f"R@5={m.recall_at_k.get(5, 0):.4f} "
+            f"R@10={m.recall_at_k.get(10, 0):.4f} "
+            f"nDCG@10={m.ndcg_at_k.get(10, 0):.4f} "
+            f"n={m.num_queries}"
+        )
+    logger.info("\n".join(lines))

--- a/nvidia_tao_deploy/multimodal/video_clip/inferencer.py
+++ b/nvidia_tao_deploy/multimodal/video_clip/inferencer.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP TensorRT inferencer (combined engine)."""
+
+import glob
+import logging
+import os
+
+import numpy as np
+import tensorrt as trt
+
+from nvidia_tao_deploy.inferencer.trt_inferencer import TRTInferencer
+from nvidia_tao_deploy.inferencer.utils import do_inference
+
+logger = logging.getLogger(__name__)
+
+
+def trt_output_process_fn(y_encoded):
+    """Process TRT model output to numpy array."""
+    return np.reshape(y_encoded.host, y_encoded.numpy_shape)
+
+
+class VideoCLIPInferencer(TRTInferencer):
+    """Manages TensorRT objects for a combined Video-CLIP model.
+
+    The combined engine has three inputs (image, input_ids, attention_mask) and
+    outputs image_embedding, text_embedding, logit_scale, and optionally
+    logit_bias. The image input is 5-D ``(B, T, C, H, W)`` for video; all shape
+    handling reads ``input_tensors[0].tensor_shape[1:]`` so the extra temporal
+    axis is transparent.
+    """
+
+    def __init__(self, engine_path, input_shape=None, batch_size=None,
+                 data_format="channel_first"):
+        """Initialize TensorRT objects for model inference.
+
+        Args:
+            engine_path (str): Path to TensorRT engine file.
+            input_shape (tuple): (batch, T, C, H, W) for dynamic engines.
+            batch_size (int): Batch size for dynamic engines.
+            data_format (str): channel_first or channel_last.
+        """
+        super().__init__(
+            engine_path,
+            input_shape=input_shape,
+            batch_size=batch_size,
+            data_format=data_format,
+        )
+        self._output_names = [t.tensor_name for t in self.output_tensors]
+
+    @property
+    def image_input_shape(self):
+        """Image input shape (T, C, H, W)."""
+        return tuple(self.input_tensors[0].tensor_shape[1:])
+
+    @property
+    def image_input_dtype(self):
+        """Numpy dtype for image input."""
+        return trt.nptype(self.input_tensors[0].tensor_dtype)
+
+    @property
+    def num_frames(self):
+        """Number of frames T from the engine's image input."""
+        return int(self.input_tensors[0].tensor_shape[1])
+
+    @property
+    def context_length(self):
+        """Text sequence length from engine input."""
+        return int(self.input_tensors[1].tensor_shape[1])
+
+    def _run(self, input_list):
+        """Low-level engine execution with an ordered input list."""
+        self._copy_input_to_host(input_list)
+        results = do_inference(
+            self.context,
+            bindings=self.bindings,
+            inputs=self.inputs,
+            outputs=self.outputs,
+            stream=self.stream,
+            batch_size=self.max_batch_size,
+            execute_v2=self.execute_async,
+            return_raw=True,
+        )
+        return [trt_output_process_fn(r) for r in results]
+
+    def _output_index(self, name):
+        return self._output_names.index(name)
+
+    def infer(self, imgs, input_ids=None, attention_mask=None):  # pylint: disable=arguments-renamed
+        """Run inference on a batch of preprocessed videos (and optional text).
+
+        Args:
+            imgs (np.ndarray): (B, T, C, H, W) preprocessed video batch.
+            input_ids (np.ndarray | None): (B, seq_len) tokenised text. If None,
+                zeros are used (text outputs are meaningless).
+            attention_mask (np.ndarray | None): (B, seq_len). If None, ones.
+
+        Returns:
+            list[np.ndarray]: All engine outputs.
+        """
+        if input_ids is None:
+            seq_len = self.input_tensors[1].tensor_shape[1]
+            input_ids = np.zeros((imgs.shape[0], seq_len), dtype=np.int64)
+        # attention_mask is inert: the exported ONNX overrides it with all-ones
+        # internally (the InternVideo2 text tower is causal + EOT-pooled), so the
+        # value passed here does not affect the output. Kept as a graph input for
+        # interface compatibility with the combined engine's 3 inputs.
+        if attention_mask is None:
+            attention_mask = np.ones_like(input_ids, dtype=np.int64)
+        return self._run([imgs, input_ids, attention_mask])
+
+    def get_image_embeddings(self, imgs):
+        """Extract L2-normalised video embeddings.
+
+        Args:
+            imgs (np.ndarray): (B, T, C, H, W) preprocessed videos.
+
+        Returns:
+            np.ndarray: (B, D) L2-normalised video features.
+        """
+        outputs = self.infer(imgs)
+        # The engine's output buffer is sized to max_batch_size; a partial final
+        # batch returns padded (zero-input) rows. Keep only the real ones.
+        feats = outputs[self._output_index("image_embedding")][:imgs.shape[0]]
+        return feats / (np.linalg.norm(feats, axis=-1, keepdims=True) + 1e-8)
+
+    def get_text_embeddings(self, input_ids):
+        """Extract L2-normalised text embeddings.
+
+        Args:
+            input_ids (np.ndarray): (B, seq_len) tokenised text.
+
+        Returns:
+            np.ndarray: (B, D) L2-normalised text features.
+        """
+        dummy_imgs = np.zeros(
+            (input_ids.shape[0], *self.input_tensors[0].tensor_shape[1:]),
+            dtype=np.float32,
+        )
+        outputs = self.infer(dummy_imgs, input_ids)
+        # Trim padded rows from a partial final batch (see get_image_embeddings).
+        feats = outputs[self._output_index("text_embedding")][:input_ids.shape[0]]
+        return feats / (np.linalg.norm(feats, axis=-1, keepdims=True) + 1e-8)
+
+
+def create_video_clip_inferencer(trt_engine, batch_size=None,
+                                 data_format="channel_first"):
+    """Return a VideoCLIPInferencer for a combined engine file or directory.
+
+    Args:
+        trt_engine (str): Path to a combined ``.engine`` file, or a directory
+            containing exactly one ``.engine`` file.
+        batch_size (int | None): Batch size for dynamic engines.
+        data_format (str): Input data format.
+
+    Returns:
+        VideoCLIPInferencer.
+
+    Raises:
+        FileNotFoundError: If no engine file is found.
+    """
+    kwargs = {"batch_size": batch_size, "data_format": data_format}
+    if os.path.isdir(trt_engine):
+        engines = sorted(glob.glob(os.path.join(trt_engine, "*.engine")))
+        if not engines:
+            raise FileNotFoundError(
+                f"No .engine files found in directory: {trt_engine}"
+            )
+        logger.info("Combined engine found in dir: %s", engines[0])
+        return VideoCLIPInferencer(engines[0], **kwargs)
+    if os.path.isfile(trt_engine):
+        return VideoCLIPInferencer(trt_engine, **kwargs)
+    raise FileNotFoundError(f"TRT engine not found: {trt_engine}")

--- a/nvidia_tao_deploy/multimodal/video_clip/scripts/__init__.py
+++ b/nvidia_tao_deploy/multimodal/video_clip/scripts/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP deploy scripts."""

--- a/nvidia_tao_deploy/multimodal/video_clip/scripts/evaluate.py
+++ b/nvidia_tao_deploy/multimodal/video_clip/scripts/evaluate.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP TensorRT multi-relevance text->video retrieval evaluation.
+
+Reproduces the tao-pytorch domain_test evaluation through the deploy TRT path:
+embed the fixed gallery of video chunks and the text queries, then score each
+query against the whole gallery by cosine similarity and compute mAP / Recall /
+nDCG against its explicit ``relevant_clip_ids`` (overall + per slice).
+"""
+
+import glob
+import json
+import logging
+import os
+
+import numpy as np
+from omegaconf import OmegaConf
+from tqdm.auto import tqdm
+from transformers import AutoTokenizer
+
+from nvidia_tao_deploy.config.multimodal.video_clip.default_config import (
+    VideoCLIPExperimentConfig as ExperimentConfig,
+)
+from nvidia_tao_deploy.multimodal.video_clip.dataloader import (
+    VideoCLIPGalleryLoader,
+    build_chunk_index,
+    canonicalize_text,
+)
+from nvidia_tao_deploy.multimodal.video_clip.evaluation import (
+    RetrievalEvaluator,
+    evaluate_by_slice,
+    log_retrieval_metrics,
+)
+from nvidia_tao_deploy.multimodal.video_clip.inferencer import (
+    create_video_clip_inferencer,
+)
+from nvidia_tao_deploy.cv.common.decorators import monitor_status
+from nvidia_tao_deploy.cv.common.hydra.hydra_runner import hydra_runner
+from nvidia_tao_deploy.cv.common.logging import status_logging
+from nvidia_tao_deploy.cv.common.logging.tlt_logging import logging as logger
+
+logging.getLogger('PIL').setLevel(logging.WARNING)
+
+spec_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def find_export_artifacts(trt_engine_path: str) -> dict:
+    """Find the exported ``*_config.yaml`` and ``*_tokenizer/`` for an engine."""
+    engine_dir = os.path.dirname(os.path.abspath(trt_engine_path))
+    parent_dir = os.path.dirname(engine_dir)
+    search_dirs = [engine_dir, os.path.join(parent_dir, "export"), parent_dir]
+
+    result = {'config_path': None, 'tokenizer_path': None}
+    for search_dir in search_dirs:
+        if not os.path.isdir(search_dir):
+            continue
+        if result['config_path'] is None:
+            matches = glob.glob(os.path.join(search_dir, "*_config.yaml"))
+            if matches:
+                result['config_path'] = matches[0]
+        if result['tokenizer_path'] is None:
+            for match in glob.glob(os.path.join(search_dir, "*_tokenizer")):
+                if os.path.isdir(match):
+                    result['tokenizer_path'] = match
+                    break
+        if result['config_path'] and result['tokenizer_path']:
+            break
+    return result
+
+
+def load_model_config(trt_engine_path: str) -> dict:
+    """Load model_type / canonicalize_text / tokenizer_path from export artifacts."""
+    artifacts = find_export_artifacts(trt_engine_path)
+    if artifacts['tokenizer_path'] is None:
+        raise FileNotFoundError(
+            f"No *_tokenizer/ directory found for engine {trt_engine_path}. "
+            "Copy the tokenizer from ONNX export next to the engine."
+        )
+    model_type, canonicalize = "internvideo2-clip-l14", False
+    if artifacts['config_path'] is not None:
+        cfg = OmegaConf.load(artifacts['config_path'])
+        model_cfg = cfg.get('model', {})
+        model_type = getattr(model_cfg, 'type', model_type)
+        canonicalize = bool(getattr(model_cfg, 'canonicalize_text', False))
+    return {
+        'model_type': model_type,
+        'canonicalize_text': canonicalize,
+        'tokenizer_path': artifacts['tokenizer_path'],
+    }
+
+
+def _embed_gallery(trt_infer, loader: VideoCLIPGalleryLoader):
+    """Return (embeddings (M, D), ordered chunk_ids) for the gallery."""
+    embs, ids = [], []
+    for videos, chunk_ids in tqdm(loader, total=len(loader), desc="Gallery videos"):
+        embs.append(trt_infer.get_image_embeddings(videos))
+        ids.extend(chunk_ids)
+    return np.concatenate(embs, axis=0), ids
+
+
+def _embed_queries(trt_infer, texts, tokenizer, context_length, batch_size,
+                   do_canonicalize=False):
+    """Return (embeddings (N, D)) for the text queries."""
+    embs = []
+    for i in tqdm(range(0, len(texts), batch_size), desc="Query text"):
+        batch = texts[i:i + batch_size]
+        if do_canonicalize:
+            batch = [canonicalize_text(t) for t in batch]
+        tokens = tokenizer(
+            batch, padding="max_length", truncation=True,
+            max_length=context_length, return_tensors="np",
+        )
+        input_ids = tokens["input_ids"].astype(np.int64)
+        embs.append(trt_infer.get_text_embeddings(input_ids))
+    return np.concatenate(embs, axis=0)
+
+
+@hydra_runner(
+    config_path=os.path.join(spec_root, "specs"),
+    config_name="experiment_spec",
+    schema=ExperimentConfig,
+)
+@monitor_status(name='video_clip', mode='evaluate')
+def main(cfg: ExperimentConfig) -> None:
+    """Video-CLIP TRT retrieval evaluation."""
+    eval_cfg = cfg.evaluate
+    val_cfg = cfg.dataset.val
+    batch_size = eval_cfg.batch_size
+    logger.info("TRT engine: %s", eval_cfg.trt_engine)
+
+    model_config = load_model_config(eval_cfg.trt_engine)
+    tokenizer = AutoTokenizer.from_pretrained(model_config['tokenizer_path'])
+
+    trt_infer = create_video_clip_inferencer(
+        eval_cfg.trt_engine, batch_size=batch_size, data_format="channel_first",
+    )
+    num_frames = trt_infer.num_frames
+    _, _, image_size, _ = trt_infer.image_input_shape
+    context_length = trt_infer.context_length
+    logger.info(
+        "Engine: T=%d, image_size=%d, context_length=%d",
+        num_frames, image_size, context_length,
+    )
+
+    # --- Ground truth: gallery (corpus) + queries (explicit relevance) --------
+    with open(val_cfg.gt_queries, "r", encoding="utf-8") as f:
+        gt = json.load(f)
+    gallery = gt["gallery"]
+    queries = gt["queries"]
+    gallery_ids = [g["chunk_id"] for g in gallery]
+    logger.info("Gallery: %d clips, Queries: %d", len(gallery_ids), len(queries))
+
+    # --- Embed gallery videos --------------------------------------------------
+    chunk_index = build_chunk_index(
+        val_cfg.metadata,
+        data_root=getattr(val_cfg, "video_root", None),
+        path_prefix_mapping=OmegaConf.to_container(
+            getattr(val_cfg, "path_prefix_mapping", {}) or {}
+        ),
+    )
+    loader = VideoCLIPGalleryLoader(
+        gallery_ids, chunk_index, num_frames=num_frames,
+        image_size=image_size, batch_size=batch_size,
+        dtype=trt_infer.image_input_dtype,
+    )
+    gallery_embs, ordered_ids = _embed_gallery(trt_infer, loader)
+    gid_to_idx = {cid: i for i, cid in enumerate(ordered_ids)}
+
+    # --- Embed query text ------------------------------------------------------
+    query_texts = [q["query"] for q in queries]
+    do_canonicalize = model_config['canonicalize_text']
+    if do_canonicalize:
+        logger.info("Applying text canonicalization before tokenization.")
+    query_embs = _embed_queries(
+        trt_infer, query_texts, tokenizer, context_length, batch_size,
+        do_canonicalize=do_canonicalize,
+    )
+
+    # --- Map relevant_clip_ids -> gallery indices; keep slices -----------------
+    ground_truth, slices, n_dropped = [], [], 0
+    for q in queries:
+        rel = [gid_to_idx[c] for c in q.get("relevant_clip_ids", []) if c in gid_to_idx]
+        n_dropped += len(q.get("relevant_clip_ids", [])) - len(rel)
+        ground_truth.append(rel)
+        slices.append(q.get("slice") or "all")
+    if n_dropped:
+        logger.warning(
+            "%d relevant_clip_ids were not present in the gallery and were "
+            "dropped from scoring.", n_dropped,
+        )
+
+    # --- Metrics ---------------------------------------------------------------
+    evaluator = RetrievalEvaluator(k_values=(1, 5, 10), compute_auc=True)
+    results = evaluate_by_slice(
+        evaluator, query_embs, gallery_embs, ground_truth, slices,
+    )
+    log_retrieval_metrics(results, prefix="TRT ")
+
+    overall = results['overall']
+    out = {name: m.to_dict() for name, m in results.items()}
+
+    s_logger = status_logging.get_status_logger()
+    s_logger.kpi = {
+        "mAP": overall.map_score,
+        "recall@1": overall.recall_at_k.get(1, 0),
+        "recall@5": overall.recall_at_k.get(5, 0),
+    }
+    s_logger.write(
+        message="Retrieval evaluation completed.",
+        status_level=status_logging.Status.SUCCESS,
+    )
+
+    results_dir = eval_cfg.results_dir or cfg.results_dir
+    os.makedirs(results_dir, exist_ok=True)
+    results_path = os.path.join(results_dir, "results.json")
+    with open(results_path, "w", encoding="utf-8") as f:
+        json.dump(out, f, indent=2)
+    logger.info("mAP (overall) = %.4f; results saved to %s",
+                overall.map_score, results_path)
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter

--- a/nvidia_tao_deploy/multimodal/video_clip/scripts/evaluate.py
+++ b/nvidia_tao_deploy/multimodal/video_clip/scripts/evaluate.py
@@ -51,7 +51,8 @@ def find_export_artifacts(trt_engine_path: str) -> dict:
     parent_dir = os.path.dirname(engine_dir)
     search_dirs = [engine_dir, os.path.join(parent_dir, "export"), parent_dir]
 
-    result = {'config_path': None, 'tokenizer_path': None}
+    result = {'config_path': None, 'tokenizer_path': None,
+              'search_dirs': search_dirs}
     for search_dir in search_dirs:
         if not os.path.isdir(search_dir):
             continue
@@ -83,6 +84,16 @@ def load_model_config(trt_engine_path: str) -> dict:
         model_cfg = cfg.get('model', {})
         model_type = getattr(model_cfg, 'type', model_type)
         canonicalize = bool(getattr(model_cfg, 'canonicalize_text', False))
+    else:
+        logger.warning(
+            "No *_config.yaml found for engine %s (searched: %s). Assuming "
+            "model.type=%s and model.canonicalize_text=%s. If the model was "
+            "exported with canonicalize_text: true, queries here are tokenized "
+            "differently than at training time and retrieval accuracy degrades "
+            "silently -- copy the exported *_config.yaml next to the engine.",
+            trt_engine_path, ", ".join(artifacts['search_dirs']),
+            model_type, canonicalize,
+        )
     return {
         'model_type': model_type,
         'canonicalize_text': canonicalize,

--- a/nvidia_tao_deploy/multimodal/video_clip/scripts/gen_trt_engine.py
+++ b/nvidia_tao_deploy/multimodal/video_clip/scripts/gen_trt_engine.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP ONNX model to TensorRT engine conversion."""
+
+import glob
+import os
+import shutil
+
+from nvidia_tao_deploy.config.multimodal.video_clip.default_config import (
+    VideoCLIPExperimentConfig as ExperimentConfig,
+)
+from nvidia_tao_deploy.multimodal.video_clip.engine_builder import VideoCLIPEngineBuilder
+from nvidia_tao_deploy.cv.common.decorators import monitor_status
+from nvidia_tao_deploy.cv.common.hydra.hydra_runner import hydra_runner
+from nvidia_tao_deploy.cv.common.initialize_experiments import (
+    initialize_gen_trt_engine_experiment,
+)
+from nvidia_tao_deploy.cv.common.logging.tlt_logging import logging as logger
+from nvidia_tao_deploy.cv.common.utils import is_qdq_quantized_onnx
+from nvidia_tao_deploy.utils.decoding import decode_model
+
+spec_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _apply_fp16_precision_constraints(builder, create_engine_kwargs):
+    """Keep sensitive vision normalization reductions in FP32."""
+    required = builder.get_fp16_precision_constraints()
+    configured = dict(create_engine_kwargs.get("layers_precision") or {})
+    configured.update(required)
+    create_engine_kwargs["layers_precision"] = configured
+    return len(required)
+
+
+@hydra_runner(
+    config_path=os.path.join(spec_root, "specs"),
+    config_name="experiment_spec",
+    schema=ExperimentConfig,
+)
+@monitor_status(name='video_clip', mode='gen_trt_engine')
+def main(cfg: ExperimentConfig) -> None:
+    """Convert a Video-CLIP ONNX model to a TensorRT engine."""
+    trt_cfg = cfg.gen_trt_engine
+    logger.info("ONNX file: %s", trt_cfg.onnx_file)
+    logger.info("Output engine: %s", trt_cfg.trt_engine)
+    logger.info("Data type: %s", trt_cfg.tensorrt.data_type)
+    logger.info(
+        "Batch size: min=%d, opt=%d, max=%d",
+        trt_cfg.tensorrt.min_batch_size,
+        trt_cfg.tensorrt.opt_batch_size,
+        trt_cfg.tensorrt.max_batch_size,
+    )
+
+    tmp_onnx_file, file_format = decode_model(trt_cfg.onnx_file)
+    logger.info("Decoded model format: %s", file_format)
+
+    engine_builder_kwargs, create_engine_kwargs = (
+        initialize_gen_trt_engine_experiment(cfg)
+    )
+
+    strongly_typed = bool(getattr(trt_cfg.tensorrt, "strongly_typed", False))
+    if strongly_typed:
+        logger.info(
+            "Strongly-typed mode enabled via config for a mixed-precision ONNX "
+            "(e.g. ModelOpt AutoCast keeping the vision RMSNorm in FP32)."
+        )
+    elif file_format == "onnx":
+        strongly_typed = is_qdq_quantized_onnx(tmp_onnx_file)
+        if strongly_typed:
+            logger.info(
+                "QDQ quantized ONNX model detected. Enabling strongly typed mode."
+            )
+
+    logger.info("Building TensorRT engine...")
+    builder = VideoCLIPEngineBuilder(
+        **engine_builder_kwargs,
+        workspace=trt_cfg.tensorrt.workspace_size,
+        strongly_typed=strongly_typed,
+        data_format="channels_first",
+    )
+    builder.create_network(tmp_onnx_file, file_format)
+    if str(trt_cfg.tensorrt.data_type).lower() == "fp16" and not strongly_typed:
+        num_constraints = _apply_fp16_precision_constraints(
+            builder, create_engine_kwargs
+        )
+        if num_constraints:
+            logger.info(
+                "Pinned %d vision block normalization layers to FP32.",
+                num_constraints,
+            )
+        else:
+            logger.warning(
+                "No decomposed vision block normalization layers were found "
+                "for FP16 precision constraints."
+            )
+    builder.create_engine(**create_engine_kwargs)
+    logger.info("Engine saved to: %s", trt_cfg.trt_engine)
+
+    _copy_export_artifacts(trt_cfg.onnx_file, trt_cfg.trt_engine)
+
+
+def _copy_export_artifacts(onnx_path, engine_path):
+    """Copy *_config.yaml and *_tokenizer/ from the ONNX dir to the engine dir."""
+    onnx_dir = os.path.dirname(os.path.abspath(onnx_path))
+    engine_dir = os.path.dirname(os.path.abspath(engine_path))
+
+    if os.path.normpath(onnx_dir) == os.path.normpath(engine_dir):
+        return
+
+    for pattern, is_dir in [("*_config.yaml", False), ("*_tokenizer", True)]:
+        for src in glob.glob(os.path.join(onnx_dir, pattern)):
+            name = os.path.basename(src)
+            dst = os.path.join(engine_dir, name)
+            if os.path.exists(dst):
+                continue
+            if is_dir and os.path.isdir(src):
+                shutil.copytree(src, dst)
+            elif not is_dir and os.path.isfile(src):
+                shutil.copy2(src, dst)
+            logger.info("Copied %s -> %s", src, dst)
+
+
+if __name__ == '__main__':
+    main()

--- a/nvidia_tao_deploy/multimodal/video_clip/scripts/inference.py
+++ b/nvidia_tao_deploy/multimodal/video_clip/scripts/inference.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP TensorRT inference — extract text and/or gallery-video embeddings.
+
+Writes HDF5 files in the same schema as the tao-pytorch trainer:
+``text_embeddings.h5`` (texts) and/or ``video_embeddings.h5`` (gallery chunk ids).
+"""
+
+import json
+import logging
+import os
+
+import h5py
+import numpy as np
+from omegaconf import OmegaConf
+from tqdm.auto import tqdm
+from transformers import AutoTokenizer
+
+from nvidia_tao_deploy.config.multimodal.video_clip.default_config import (
+    VideoCLIPExperimentConfig as ExperimentConfig,
+)
+from nvidia_tao_deploy.multimodal.video_clip.dataloader import (
+    VideoCLIPGalleryLoader,
+    build_chunk_index,
+    canonicalize_text,
+)
+from nvidia_tao_deploy.multimodal.video_clip.inferencer import (
+    create_video_clip_inferencer,
+)
+from nvidia_tao_deploy.multimodal.video_clip.scripts.evaluate import load_model_config
+from nvidia_tao_deploy.cv.common.decorators import monitor_status
+from nvidia_tao_deploy.cv.common.hydra.hydra_runner import hydra_runner
+from nvidia_tao_deploy.cv.common.logging.tlt_logging import logging as logger
+
+logging.getLogger('PIL').setLevel(logging.WARNING)
+
+spec_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _save_embeddings(items, embeddings, path, items_key, count_key, embedding_type):
+    """Save embeddings + item ids to HDF5 (tao-pytorch schema)."""
+    with h5py.File(path, 'w') as f:
+        f.create_dataset('embeddings', data=embeddings.astype(np.float32),
+                         compression='gzip', compression_opts=4)
+        dt = h5py.special_dtype(vlen=str)
+        ds = f.create_dataset(items_key, (len(items),), dtype=dt)
+        for i, item in enumerate(items):
+            ds[i] = item
+        f.attrs[count_key] = len(items)
+        f.attrs['embedding_dim'] = embeddings.shape[1]
+        f.attrs['embedding_type'] = embedding_type
+    logger.info("Saved %d %s embeddings to %s", len(items), embedding_type, path)
+
+
+@hydra_runner(
+    config_path=os.path.join(spec_root, "specs"),
+    config_name="experiment_spec",
+    schema=ExperimentConfig,
+)
+@monitor_status(name='video_clip', mode='inference')
+def main(cfg: ExperimentConfig) -> None:
+    """Extract text and/or gallery-video embeddings via TRT."""
+    infer_cfg = cfg.inference
+    val_cfg = cfg.dataset.val
+    batch_size = infer_cfg.batch_size
+    results_dir = infer_cfg.results_dir or cfg.results_dir
+    os.makedirs(results_dir, exist_ok=True)
+
+    model_config = load_model_config(infer_cfg.trt_engine)
+    trt_infer = create_video_clip_inferencer(
+        infer_cfg.trt_engine, batch_size=batch_size, data_format="channel_first",
+    )
+
+    did_something = False
+
+    # Text embeddings from a prompt file.
+    if infer_cfg.text_file:
+        with open(infer_cfg.text_file, "r", encoding="utf-8") as f:
+            texts = [ln.strip() for ln in f if ln.strip()]
+        tokenizer = AutoTokenizer.from_pretrained(model_config['tokenizer_path'])
+        ctx = trt_infer.context_length
+        do_canonicalize = model_config['canonicalize_text']
+        embs = []
+        for i in tqdm(range(0, len(texts), batch_size), desc="Text embeddings"):
+            batch = texts[i:i + batch_size]
+            if do_canonicalize:
+                batch = [canonicalize_text(t) for t in batch]
+            tokens = tokenizer(batch, padding="max_length",
+                               truncation=True, max_length=ctx, return_tensors="np")
+            embs.append(trt_infer.get_text_embeddings(
+                tokens["input_ids"].astype(np.int64)))
+        _save_embeddings(texts, np.concatenate(embs, 0),
+                         os.path.join(results_dir, "text_embeddings.h5"),
+                         "texts", "num_texts", "text")
+        did_something = True
+
+    # Gallery-video embeddings from the eval GT + chunk metadata.
+    gt_queries = getattr(val_cfg, "gt_queries", None)
+    metadata = getattr(val_cfg, "metadata", None)
+    if gt_queries and metadata:
+        with open(gt_queries, "r", encoding="utf-8") as f:
+            gallery_ids = [g["chunk_id"] for g in json.load(f)["gallery"]]
+        chunk_index = build_chunk_index(
+            metadata, data_root=getattr(val_cfg, "video_root", None),
+            path_prefix_mapping=OmegaConf.to_container(
+                getattr(val_cfg, "path_prefix_mapping", {}) or {}),
+        )
+        loader = VideoCLIPGalleryLoader(
+            gallery_ids, chunk_index, num_frames=trt_infer.num_frames,
+            image_size=trt_infer.image_input_shape[2], batch_size=batch_size,
+            dtype=trt_infer.image_input_dtype,
+        )
+        embs, ids = [], []
+        for videos, chunk_ids in tqdm(loader, total=len(loader), desc="Gallery videos"):
+            embs.append(trt_infer.get_image_embeddings(videos))
+            ids.extend(chunk_ids)
+        _save_embeddings(ids, np.concatenate(embs, 0),
+                         os.path.join(results_dir, "video_embeddings.h5"),
+                         "chunk_ids", "num_videos", "video")
+        did_something = True
+
+    if not did_something:
+        raise ValueError(
+            "Nothing to do: set inference.text_file and/or dataset.val."
+            "{gt_queries,metadata}."
+        )
+    logger.info("Inference complete.")
+
+
+if __name__ == '__main__':
+    main()  # pylint: disable=no-value-for-parameter

--- a/nvidia_tao_deploy/multimodal/video_clip/specs/experiment_spec.yaml
+++ b/nvidia_tao_deploy/multimodal/video_clip/specs/experiment_spec.yaml
@@ -1,0 +1,53 @@
+# Video-CLIP (InternVideo2-CLIP) TensorRT Deployment Configuration
+#
+# Tasks:
+# - gen_trt_engine: Convert the combined ONNX model to a TensorRT engine
+# - evaluate:       Multi-relevance text->video retrieval (mAP / Recall / nDCG)
+# - inference:      Extract text and/or gallery-video embeddings to HDF5
+
+results_dir: ???
+
+model:
+  type: internvideo2-clip-l14
+  image_size: 224              # overridden by the engine's image input at runtime
+  canonicalize_text: false
+
+# =============================================================================
+# TensorRT Engine Generation
+# =============================================================================
+gen_trt_engine:
+  onnx_file: ???               # combined ONNX (image + text) from tao-pytorch export
+  trt_engine: ???              # output TensorRT engine path
+  batch_size: -1               # -1 for dynamic batch
+  tensorrt:
+    workspace_size: 8192       # MB
+    data_type: fp32            # fp32 required — fp16 collapses the vision tower
+    min_batch_size: 1
+    opt_batch_size: 8
+    max_batch_size: 16
+
+# =============================================================================
+# Dataset (gallery + explicit-relevance queries) for evaluation/inference
+# =============================================================================
+dataset:
+  val:
+    gt_queries: ???            # domain_test_*.json with 'gallery' + 'queries'
+    metadata: ???              # vadr1_chunks JSON to resolve chunk_id -> video/time
+    video_root: null           # optional root for relative video paths
+    path_prefix_mapping: {}     # e.g. {"/workspace/data": "/home/alicli/data"}
+    batch_size: 8
+
+# =============================================================================
+# Retrieval Evaluation
+# =============================================================================
+evaluate:
+  trt_engine: ???
+  batch_size: 8
+
+# =============================================================================
+# Inference
+# =============================================================================
+inference:
+  trt_engine: ???
+  batch_size: 8
+  text_file: null              # optional: one prompt per line -> text_embeddings.h5

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setuptools.setup(
             'nvdinov2=nvidia_tao_deploy.cv.nvdinov2.entrypoint.nvdinov2:main',
             'mae=nvidia_tao_deploy.cv.mae.entrypoint.mae:main',
             'clip=nvidia_tao_deploy.multimodal.clip.entrypoint.clip:main',
+            'video_clip=nvidia_tao_deploy.multimodal.video_clip.entrypoint.video_clip:main',
         ]
     }
 )

--- a/tests/clip/__init__.py
+++ b/tests/clip/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLIP Unit Tests."""

--- a/tests/video_clip/__init__.py
+++ b/tests/video_clip/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video CLIP Unit Tests."""

--- a/tests/video_clip/test_config.py
+++ b/tests/video_clip/test_config.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP deploy config unit tests."""
+
+from nvidia_tao_deploy.config.multimodal.video_clip.default_config import (
+    VideoCLIPTrtConfig,
+    VideoCLIPModelConfig,
+)
+
+
+def test_default_precision_is_fp32():
+    """FP32 remains the conservative default precision."""
+    assert VideoCLIPTrtConfig().data_type == "fp32"
+
+
+def test_default_image_size_and_type():
+    m = VideoCLIPModelConfig()
+    assert m.image_size == 224
+    assert m.type == "internvideo2-clip-l14"
+    assert m.canonicalize_text is False

--- a/tests/video_clip/test_dataloader.py
+++ b/tests/video_clip/test_dataloader.py
@@ -90,6 +90,12 @@ class TestChunkIndex:
         )
         assert idx["CHAD/1_086_1#0"]["video_path"] == "/mnt/local/a.mp4"
 
+    def test_data_root_does_not_rewrite_absolute_paths(self, tmp_path):
+        # data_root only prefixes RELATIVE paths; absolute paths pass through
+        # untouched. Remapping absolute paths is path_prefix_mapping's job.
+        idx = build_chunk_index(self._write_meta(tmp_path), data_root="/mnt/local")
+        assert idx["CHAD/1_086_1#0"]["video_path"] == "/data/a.mp4"
+
     def test_gallery_loader_missing_id_raises(self, tmp_path):
         idx = build_chunk_index(self._write_meta(tmp_path))
         with pytest.raises(KeyError):

--- a/tests/video_clip/test_dataloader.py
+++ b/tests/video_clip/test_dataloader.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP dataloader unit tests (frame preprocessing + chunk resolution).
+
+These are the train/serve preprocessing-parity guards in unit form.
+"""
+
+import json
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from nvidia_tao_deploy.multimodal.video_clip.dataloader import (
+    IMAGENET_MEAN,
+    IMAGENET_STD,
+    VideoCLIPGalleryLoader,
+    build_chunk_index,
+    canonicalize_text,
+    linspace_indices,
+    preprocess_frames,
+)
+
+
+class TestLinspaceIndices:
+    def test_enough_frames_uniform(self):
+        idx = linspace_indices(100, 8)
+        assert idx.tolist() == [0, 14, 28, 42, 56, 70, 84, 99]
+
+    def test_fewer_frames_repeat_last(self):
+        idx = linspace_indices(3, 8)
+        assert idx.tolist() == [0, 1, 2, 2, 2, 2, 2, 2]
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError):
+            linspace_indices(0, 8)
+
+
+class TestPreprocessFrames:
+    def test_shape_and_dtype(self):
+        frames = [Image.new("RGB", (64, 48), (10, 20, 30)) for _ in range(8)]
+        out = preprocess_frames(frames, 224)
+        assert out.shape == (8, 3, 224, 224)
+        assert out.dtype == np.float32
+        assert np.isfinite(out).all()
+
+    def test_imagenet_normalization_and_channel_order(self):
+        # Solid colour -> every pixel equals (c/255 - mean)/std, per channel.
+        color = (255, 0, 128)
+        out = preprocess_frames([Image.new("RGB", (32, 32), color)], 224)
+        expected = (np.array(color, np.float32) / 255.0 - IMAGENET_MEAN) / IMAGENET_STD
+        for c in range(3):
+            np.testing.assert_allclose(out[0, c], expected[c], rtol=1e-4, atol=1e-4)
+
+    def test_not_clip_normalization(self):
+        # Guard against accidentally using CLIP mean/std (0.481.., 0.268..).
+        # Use black, where ImageNet (-2.118) and CLIP (-1.792) norms differ sharply.
+        out = preprocess_frames([Image.new("RGB", (16, 16), (0, 0, 0))], 224)
+        clip_expected = (0.0 - 0.48145466) / 0.26862954   # channel 0, CLIP norm
+        assert abs(float(out[0, 0, 0, 0]) - clip_expected) > 0.1
+
+
+class TestChunkIndex:
+    def _write_meta(self, tmp_path):
+        data = [{
+            "dataset": "CHAD", "video_id": "1_086_1", "video_path": "/data/a.mp4",
+            "chunks": [
+                {"chunk_index": 0, "start_time_sec": 0.0, "end_time_sec": 4.0,
+                 "start_frame": 0, "end_frame": 120},
+                {"chunk_index": 1, "start_time_sec": 4.0, "end_time_sec": 8.0,
+                 "start_frame": 120, "end_frame": 240},
+            ],
+        }]
+        p = tmp_path / "meta.json"
+        p.write_text(json.dumps(data))
+        return str(p)
+
+    def test_sample_id_format_and_fields(self, tmp_path):
+        idx = build_chunk_index(self._write_meta(tmp_path))
+        assert "CHAD/1_086_1#0" in idx and "CHAD/1_086_1#1" in idx
+        rec = idx["CHAD/1_086_1#0"]
+        assert rec["video_path"] == "/data/a.mp4"
+        assert rec["end_frame"] == 120
+
+    def test_path_prefix_mapping(self, tmp_path):
+        idx = build_chunk_index(
+            self._write_meta(tmp_path),
+            path_prefix_mapping={"/data": "/mnt/local"},
+        )
+        assert idx["CHAD/1_086_1#0"]["video_path"] == "/mnt/local/a.mp4"
+
+    def test_gallery_loader_missing_id_raises(self, tmp_path):
+        idx = build_chunk_index(self._write_meta(tmp_path))
+        with pytest.raises(KeyError):
+            VideoCLIPGalleryLoader(
+                ["CHAD/1_086_1#0", "MISSING/x#0"], idx,
+                num_frames=8, image_size=224,
+            )
+
+    def test_wrapped_data_key(self, tmp_path):
+        # {"data": [...]} form is accepted.
+        recs = json.loads(open(self._write_meta(tmp_path)).read())
+        p = tmp_path / "wrapped.json"
+        p.write_text(json.dumps({"data": recs}))
+        idx = build_chunk_index(str(p))
+        assert "CHAD/1_086_1#0" in idx
+
+    def test_bad_format_raises_clear_error(self, tmp_path):
+        # A dict without a list 'data' is a clear ValueError, not an AttributeError.
+        p = tmp_path / "bad.json"
+        p.write_text(json.dumps({"CHAD/1_086_1#0": {"video_path": "/x.mp4"}}))
+        with pytest.raises(ValueError, match="Unrecognized chunk-metadata format"):
+            build_chunk_index(str(p))
+
+
+class TestCanonicalizeText:
+    def test_lowercase_and_strip_punctuation(self):
+        assert canonicalize_text("A Black_Car, running!") == "a black car running"
+
+    def test_collapses_whitespace(self):
+        assert canonicalize_text("  two   people  ") == "two people"

--- a/tests/video_clip/test_engine_builder.py
+++ b/tests/video_clip/test_engine_builder.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP Engine Builder Unit Tests."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from nvidia_tao_deploy.multimodal.video_clip.engine_builder import VideoCLIPEngineBuilder
+from nvidia_tao_deploy.engine.builder import EngineBuilder
+from nvidia_tao_deploy.multimodal.video_clip.scripts.gen_trt_engine import (
+    _apply_fp16_precision_constraints,
+)
+
+
+class TestVideoCLIPEngineBuilderInit:
+    """Tests for VideoCLIPEngineBuilder initialization."""
+
+    @patch.object(EngineBuilder, '__init__', return_value=None)
+    def test_default_data_format(self, mock_init):
+        builder = VideoCLIPEngineBuilder()
+        assert builder._data_format == "channels_first"
+        mock_init.assert_called_once_with()
+
+    @patch.object(EngineBuilder, '__init__', return_value=None)
+    def test_kwargs_forwarded(self, mock_init):
+        VideoCLIPEngineBuilder(
+            data_format="channels_first",
+            workspace=8192,
+            max_batch_size=16,
+            strongly_typed=True,
+        )
+        mock_init.assert_called_once_with(
+            workspace=8192,
+            max_batch_size=16,
+            strongly_typed=True,
+        )
+
+    def test_inherits_engine_builder(self):
+        assert issubclass(VideoCLIPEngineBuilder, EngineBuilder)
+
+
+class TestFP16PrecisionConstraints:
+    """Tests for InternVideo2 FP16 normalization safeguards."""
+
+    def test_selects_only_block_norm_reductions(self):
+        builder = VideoCLIPEngineBuilder.__new__(VideoCLIPEngineBuilder)
+        selected = [
+            "/model/vision_encoder/blocks.0/norm1/Pow",
+            "/model/vision_encoder/blocks.0/norm1/ReduceMean",
+            "/model/vision_encoder/blocks.23/norm2/Pow",
+            "/model/vision_encoder/blocks.23/norm2/ReduceMean",
+        ]
+        excluded = [
+            "/model/vision_encoder/blocks.0/attn/q_norm/Pow",
+            "/model/vision_encoder/clip_projector/ReduceMean",
+            "/model/text_encoder/transformer.0/LayerNormalization",
+        ]
+        builder.network = [
+            SimpleNamespace(name=name) for name in selected + excluded
+        ]
+
+        assert builder.get_fp16_precision_constraints() == {
+            name: "fp32" for name in selected
+        }
+
+    def test_required_constraints_override_only_matching_entries(self):
+        required_name = "/model/vision_encoder/blocks.0/norm1/Pow"
+        builder = SimpleNamespace(
+            get_fp16_precision_constraints=lambda: {required_name: "fp32"}
+        )
+        kwargs = {
+            "layers_precision": {
+                required_name: "fp16",
+                "/custom/layer": "fp16",
+            }
+        }
+
+        count = _apply_fp16_precision_constraints(builder, kwargs)
+
+        assert count == 1
+        assert kwargs["layers_precision"] == {
+            required_name: "fp32",
+            "/custom/layer": "fp16",
+        }

--- a/tests/video_clip/test_entrypoint.py
+++ b/tests/video_clip/test_entrypoint.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP entrypoint unit test — subtask discovery."""
+
+from nvidia_tao_deploy.multimodal.video_clip.entrypoint.video_clip import (
+    get_subtask_list,
+)
+
+
+def test_subtasks_present():
+    subtasks = get_subtask_list()
+    for name in ("gen_trt_engine", "evaluate", "inference"):
+        assert name in subtasks

--- a/tests/video_clip/test_evaluation.py
+++ b/tests/video_clip/test_evaluation.py
@@ -57,6 +57,25 @@ class TestRetrievalEvaluator:
         assert m.map_score == 0.0
 
 
+class TestRetrievalAUC:
+    """AUC needs scores and labels in the SAME order; ranked labels alone are not enough."""
+
+    def setup_method(self):
+        self.gallery = np.eye(4, dtype=np.float32)
+        # sims = [1,2,3,4]/||q||, so the ranking order [3,2,1,0] is NOT the
+        # gallery order -- a misaligned call gives the exact opposite answer.
+        self.q = np.array([[1, 2, 3, 4]], dtype=np.float32)
+        self.ev = RetrievalEvaluator(k_values=(1,), compute_auc=True)
+
+    def test_only_lowest_scoring_clip_relevant_is_auc_zero(self):
+        m = self.ev.evaluate(self.q, self.gallery, [[0]])
+        assert abs(m.auc - 0.0) < 1e-6
+
+    def test_only_highest_scoring_clip_relevant_is_auc_one(self):
+        m = self.ev.evaluate(self.q, self.gallery, [[3]])
+        assert abs(m.auc - 1.0) < 1e-6
+
+
 class TestEvaluateBySlice:
     def test_slice_split_and_overall(self):
         gallery = np.eye(3, dtype=np.float32)

--- a/tests/video_clip/test_evaluation.py
+++ b/tests/video_clip/test_evaluation.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP retrieval metric unit tests (pure numpy, deterministic)."""
+
+import numpy as np
+
+from nvidia_tao_deploy.multimodal.video_clip.evaluation import (
+    RetrievalEvaluator,
+    compute_ap,
+    evaluate_by_slice,
+)
+
+
+class TestComputeAP:
+    def test_all_relevant_first(self):
+        assert compute_ap(np.array([1.0, 1.0, 0.0, 0.0])) == 1.0
+
+    def test_textbook_interleaved(self):
+        # relevant at ranks 2 and 4 -> (1/2 + 2/4) / 2 = 0.5
+        assert compute_ap(np.array([0.0, 1.0, 0.0, 1.0])) == 0.5
+
+    def test_no_relevant_is_zero(self):
+        assert compute_ap(np.array([0.0, 0.0, 0.0])) == 0.0
+
+
+class TestRetrievalEvaluator:
+    """Deterministic cases: gallery = identity basis, ties broken by index."""
+
+    def setup_method(self):
+        self.gallery = np.eye(4, dtype=np.float32)          # 4 clips, D=4
+        self.ev = RetrievalEvaluator(k_values=(1, 2), compute_auc=False)
+
+    def test_perfect_single_relevant(self):
+        q = np.array([[1, 0, 0, 0]], dtype=np.float32)      # ranks clip0 first
+        m = self.ev.evaluate(q, self.gallery, [[0]])
+        assert m.map_score == 1.0
+        assert m.recall_at_k[1] == 1.0
+
+    def test_relevant_at_rank_two(self):
+        # sims=[1,0,0,0]; stable argsort -> order [0,1,2,3]; relevant={1} at rank2
+        q = np.array([[1, 0, 0, 0]], dtype=np.float32)
+        m = self.ev.evaluate(q, self.gallery, [[1]])
+        assert abs(m.map_score - 0.5) < 1e-6
+
+    def test_multi_relevance_average(self):
+        # query favours clips 0 and 1 equally; relevant={0,2}
+        q = np.array([[1, 1, 0, 0]], dtype=np.float32) / np.sqrt(2)
+        m = self.ev.evaluate(q, self.gallery, [[0, 2]])
+        # order [0,1,2,3]; labels [1,0,1,0] -> (1/1 + 2/3)/2 = 0.8333
+        assert abs(m.map_score - (1.0 + 2.0 / 3.0) / 2.0) < 1e-6
+
+    def test_empty_relevant_skipped(self):
+        q = np.array([[1, 0, 0, 0]], dtype=np.float32)
+        m = self.ev.evaluate(q, self.gallery, [[]])
+        assert m.num_queries == 0
+        assert m.map_score == 0.0
+
+
+class TestEvaluateBySlice:
+    def test_slice_split_and_overall(self):
+        gallery = np.eye(3, dtype=np.float32)
+        q = np.array([[1, 0, 0], [0, 1, 0]], dtype=np.float32)
+        gt = [[0], [1]]  # both perfect
+        slices = ["anomaly", "specific"]
+        ev = RetrievalEvaluator(k_values=(1,), compute_auc=False)
+        res = evaluate_by_slice(ev, q, gallery, gt, slices)
+        assert set(res) == {"overall", "anomaly", "specific"}
+        assert res["overall"].map_score == 1.0
+        assert res["anomaly"].num_queries == 1
+        assert res["specific"].num_queries == 1

--- a/tests/video_clip/test_inferencer.py
+++ b/tests/video_clip/test_inferencer.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video-CLIP Inferencer Unit Tests (CPU-only, mocked TRT)."""
+
+import numpy as np
+import pytest
+import tensorrt as trt
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from nvidia_tao_deploy.multimodal.video_clip.inferencer import (
+    VideoCLIPInferencer,
+    create_video_clip_inferencer,
+    trt_output_process_fn,
+)
+from nvidia_tao_deploy.inferencer.trt_inferencer import TRTInferencer
+
+
+def _mock_output_tensors():
+    return [
+        SimpleNamespace(tensor_name="image_embedding"),
+        SimpleNamespace(tensor_name="text_embedding"),
+        SimpleNamespace(tensor_name="logit_scale"),
+        SimpleNamespace(tensor_name="logit_bias"),
+    ]
+
+
+def _mock_input_tensors():
+    # 5-D video image input (B, T=8, C=3, H=224, W=224) + (B, 77) text inputs
+    return [
+        SimpleNamespace(tensor_shape=(1, 8, 3, 224, 224), tensor_dtype=trt.float32),
+        SimpleNamespace(tensor_shape=(1, 77), tensor_dtype=trt.int32),
+        SimpleNamespace(tensor_shape=(1, 77), tensor_dtype=trt.int32),
+    ]
+
+
+def _make_infer():
+    def mock_parent_init(self, *args, **kwargs):
+        self.output_tensors = _mock_output_tensors()
+        self.trt_runtime = None
+        self.context = None
+        self.engine = None
+        self.stream = None
+        self.inputs = []
+        self.outputs = []
+
+    with patch.object(TRTInferencer, '__init__', mock_parent_init):
+        infer = VideoCLIPInferencer("/fake/engine")
+    infer.input_tensors = _mock_input_tensors()
+    infer._copy_input_to_host = MagicMock()
+    infer.context = MagicMock()
+    infer.bindings, infer.inputs, infer.outputs = [], [], []
+    infer.stream = MagicMock()
+    infer.max_batch_size = 1
+    infer.execute_async = True
+    return infer
+
+
+class TestProperties:
+    def test_inherits_trt_inferencer(self):
+        assert issubclass(VideoCLIPInferencer, TRTInferencer)
+
+    def test_image_input_shape_is_5d(self):
+        infer = _make_infer()
+        assert infer.image_input_shape == (8, 3, 224, 224)
+
+    def test_num_frames(self):
+        assert _make_infer().num_frames == 8
+
+    def test_context_length(self):
+        assert _make_infer().context_length == 77
+
+    def test_image_input_dtype(self):
+        assert _make_infer().image_input_dtype == np.float32
+
+
+class TestEmbeddings:
+    def test_get_image_embeddings_normalized(self):
+        infer = _make_infer()
+        raw = np.array([[3.0, 4.0]], dtype=np.float32)  # norm 5 -> normalizes to 1
+        outputs = [raw, np.zeros((1, 2)), np.array([1.0]), np.array([0.0])]
+        with patch.object(infer, '_run', return_value=outputs):
+            result = infer.get_image_embeddings(
+                np.zeros((1, 8, 3, 224, 224), dtype=np.float32))
+        np.testing.assert_allclose(np.linalg.norm(result, axis=-1), 1.0, rtol=1e-5)
+
+    def test_get_text_embeddings_builds_5d_dummy(self):
+        infer = _make_infer()
+        raw = np.array([[5.0, 12.0]], dtype=np.float32)  # norm 13
+        outputs = [np.zeros((1, 2)), raw, np.array([1.0]), np.array([0.0])]
+        with patch.object(infer, '_run', return_value=outputs) as mock_run:
+            result = infer.get_text_embeddings(np.zeros((1, 77), dtype=np.int64))
+            # _run was called with a 5-D dummy image matching the engine input
+            called_imgs = mock_run.call_args[0][0][0]
+            assert called_imgs.shape == (1, 8, 3, 224, 224)
+        np.testing.assert_allclose(np.linalg.norm(result, axis=-1), 1.0, rtol=1e-5)
+
+    def test_partial_batch_output_is_trimmed(self):
+        # Engine returns max_batch_size rows; a 3-image input must yield 3 rows,
+        # dropping the padded (zero-input) rows. Mock a 5-row padded output.
+        infer = _make_infer()
+        padded = np.random.rand(5, 2).astype(np.float32)
+        outputs = [padded, padded, np.array([1.0]), np.array([0.0])]
+        with patch.object(infer, '_run', return_value=outputs):
+            imgs = np.zeros((3, 8, 3, 224, 224), dtype=np.float32)
+            img_res = infer.get_image_embeddings(imgs)
+            txt_res = infer.get_text_embeddings(np.zeros((3, 77), dtype=np.int64))
+        assert img_res.shape == (3, 2)
+        assert txt_res.shape == (3, 2)
+
+    def test_infer_auto_fills_ids_and_mask(self):
+        infer = _make_infer()
+        outputs = [np.zeros((1, 2)), np.zeros((1, 2)), np.array([1.0]), np.array([0.0])]
+        with patch(
+            'nvidia_tao_deploy.multimodal.video_clip.inferencer.do_inference',
+            return_value=[SimpleNamespace(host=np.zeros(2), numpy_shape=(1, 2))] * 4,
+        ):
+            infer.infer(np.zeros((1, 8, 3, 224, 224), dtype=np.float32))
+        call_args = infer._copy_input_to_host.call_args[0][0]
+        assert len(call_args) == 3
+        assert call_args[1].shape == (1, 77) and call_args[1].dtype == np.int64
+        assert call_args[2].shape == (1, 77)
+        np.testing.assert_array_equal(call_args[2], np.ones((1, 77), dtype=np.int64))
+
+
+class TestFactory:
+    def test_combined_engine_file(self, tmp_path):
+        engine = tmp_path / "model.engine"
+        engine.write_bytes(b"fake")
+
+        def mock_init(self, *args, **kwargs):
+            self.output_tensors = _mock_output_tensors()
+            self.input_tensors = _mock_input_tensors()
+            self.trt_runtime = None
+
+        with patch.object(TRTInferencer, '__init__', mock_init):
+            result = create_video_clip_inferencer(str(engine))
+        assert isinstance(result, VideoCLIPInferencer)
+
+    def test_missing_engine_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            create_video_clip_inferencer(str(tmp_path / "nope.engine"))
+
+
+def test_trt_output_process_fn_reshape():
+    out = SimpleNamespace(host=np.arange(6, dtype=np.float32), numpy_shape=(2, 3))
+    assert trt_output_process_fn(out).shape == (2, 3)


### PR DESCRIPTION
## Summary
Adds the deploy-side counterpart of the tao-pytorch `video_clip` task: build a TensorRT engine from the exported InternVideo2-CLIP ONNX, then run retrieval inference and evaluation against it.

## Changes
- **`video_clip` entrypoint** with `gen_trt_engine`, `inference` and `evaluate` subtasks, the shipped experiment spec, and the config dataclasses under `config/multimodal/video_clip/`.
- **Dataloader** mirroring the training-time contract — frame sampling, ImageNet (not CLIP) normalization, and optional text canonicalization gated on the exported model config — so deploy-time preprocessing matches training exactly. A mismatch here degrades retrieval silently rather than failing.
- **Retrieval evaluation** — mAP, Recall@K, median and mean rank over the combined video and text embeddings.
- **`EngineBuilder._extra_network_flags()`** — a new overridable hook on the shared builder, defaulting to `0`, OR-ed into the `create_network` flags. `video_clip` overrides it to request a strongly-typed network, which is what stops TensorRT's weakly-typed fp16 path from re-interpreting the AutoCast mixed-precision ONNX. No behaviour change for any existing network.

## Testing
- Unit tests covering the config, dataloader preprocessing, engine builder, entrypoint wiring, retrieval metrics and inferencer.
- `pre-commit` (docs supported-commands, license header, pylint, pydocstyle, flake8) clean over the full diff range.
- End-to-end engine build, inference and evaluation validated against the exported InternVideo2-CLIP ONNX.

## Migration provenance
Manual migration of GitLab MR [!205](https://gitlab-master.nvidia.com/nvidia-tao-toolkit/tao-deploy/-/merge_requests/205) (branch `alicli/iv2clip`). The GitHub and GitLab repositories share no git history, so the branch's net diff was replayed onto `main` as three logical commits. Two notes:

- The source branch had advanced past the MR snapshot — it now includes the strongly-typed TRT build and the fp16 normalization fix — so the **current branch tip** was ported, not the older MR diff.
- `docs/supported_commands.md` is regenerated by the repo's own `update-docs-supported-commands` hook and is included here.

Depends on the tao-pytorch PR for the exported model this module consumes.
