### PR TITLE
[TAO-2523][Docs] Refresh developer docs: codebase tour, deeper architecture, GitHub-era CI

### DIFF
--- a/docs/agent_onboarding.md
+++ b/docs/agent_onboarding.md
@@ -1,7 +1,35 @@
 # Agent Onboarding
 
 This guide is the fast path for coding agents and new maintainers. It favors
-source-backed orientation over assumptions.
+source-backed orientation over assumptions. For a full directory walk, read the
+[Codebase tour](codebase_tour.md).
+
+## Mental Model
+
+TAO Deploy is a deployment runtime repository, not a training repository. Most
+commands accept an exported model, build or load a TensorRT engine, run
+inference or evaluation, and write outputs under a results directory.
+
+The normal flow is:
+
+```text
+console command (setup.py)
+  -> nvidia_tao_deploy/cv/common/entrypoint/entrypoint_hydra.py  (or entrypoint_proto.py)
+  -> nvidia_tao_deploy/<cv|multimodal>/<model>/scripts/<subtask>.py   (fresh subprocess)
+  -> Hydra spec validated against nvidia_tao_deploy/config/<model>/
+  -> EngineBuilder / TRTInferencer / dataloader / metrics
+```
+
+The important layers are:
+
+| Layer | What to inspect |
+| :--- | :--- |
+| Launcher | `scripts/envsetup.sh`, `runner/tao_deploy.py`, `docker/manifest.json` |
+| Installed commands | `setup.py` console scripts |
+| Model dispatch | `<model>/entrypoint/*.py` and `<model>/scripts/*.py` |
+| Configuration | `nvidia_tao_deploy/config/<model>/` and `<model>/specs/` |
+| TensorRT runtime | `nvidia_tao_deploy/engine/`, `nvidia_tao_deploy/inferencer/`, model-specific builders |
+| Validation | `tests/`, `.pre-commit-config.yaml`, `.github/workflows/` |
 
 ## First Audit
 
@@ -14,43 +42,45 @@ git branch -vv
 git -c filter.lfs.process= -c filter.lfs.required=false status --short --branch
 find . -maxdepth 2 -type d
 sed -n '1,220p' README.md
-sed -n '1,220p' .gitlab-ci.yml
 rg -n "console_scripts|entry_points" setup.py
-find runner docker release tests ci -maxdepth 2 -type f
+ls .github/workflows/
+sed -n '1,80p' .pre-commit-config.yaml
 ```
 
 Use the LFS-disabled `git status` form when the local checkout cannot write to
-`.git/lfs/tmp`.
+`.git/lfs/tmp`. Initialize the submodule before running anything:
+
+```sh
+git submodule update --init
+```
 
 ## Runtime Trace
 
 When a task touches command behavior, gather the real flow with:
 
 ```sh
-rg -n "ArgumentParser|docker/manifest|manifest.json|docker run|--gpus|--tag|--run_as_user" runner scripts docker release
+rg -n "ArgumentParser|docker/manifest|manifest.json|docker run|--gpus|--tag" runner scripts docker release
 rg -n "hydra_runner|default_specs|get_subtasks|entrypoint|console_scripts" nvidia_tao_deploy setup.py
-rg -n "pytest|run_static|pre-commit|flake8|pylint" .gitlab-ci.yml ci tests
+rg -n "config_name=" nvidia_tao_deploy/cv/<model>/scripts/
 ```
 
 Then inspect the specific model package under `nvidia_tao_deploy/cv/` or
 `nvidia_tao_deploy/multimodal/`.
 
-## Mental Model
+## Common Agent Questions
 
-TAO Deploy is a deployment runtime repository, not a training repository. Most
-commands accept an exported model, build or load a TensorRT engine, run
-inference or evaluation, and write outputs under a results directory.
-
-The important layers are:
-
-| Layer | What to inspect |
+| Question | Where to look |
 | :--- | :--- |
-| Launcher | `scripts/envsetup.sh`, `runner/tao_deploy.py`, `docker/manifest.json` |
-| Installed commands | `setup.py` console scripts |
-| Model dispatch | `MODEL_NAME/entrypoint/*.py` and `MODEL_NAME/scripts/*.py` |
-| Config | `nvidia_tao_deploy/config/MODEL_NAME/` and `MODEL_NAME/specs/` |
-| TensorRT runtime | `nvidia_tao_deploy/engine/`, `nvidia_tao_deploy/inferencer/`, model-specific builders |
-| Validation | `ci/`, `tests/`, `.gitlab-ci.yml` |
+| What command invokes this package? | `setup.py` `console_scripts` |
+| What subtasks exist? | `<model>/scripts/*.py` and [Supported commands](supported_commands.md) |
+| Is this a Hydra or proto family? | Hydra families have `nvidia_tao_deploy/config/<model>/`; proto families have `<model>/proto/` |
+| What configuration fields are valid? | `nvidia_tao_deploy/config/<model>/default_config.py` |
+| Which specification template does a subtask load? | The script's `hydra_runner(config_name=...)`, not the script filename |
+| Where is the engine built? | `<model>/engine_builder.py` if present, else a sibling family's (for example, `dino` uses the `deformable_detr` builder), else `engine/builder.py` |
+| Where does inference run? | `<model>/inferencer.py` or `inferencer/trt_inferencer.py` |
+| How is an `.etlt` file decoded? | `nvidia_tao_deploy/utils/decoding.py::decode_model` |
+| How do I add a new backend? | [Deploy backend integration](deploy_backend_integration.md) |
+| How do I run in containers? | [Container power users](container_power_users.md) |
 
 ## Dirty Worktree Safety
 
@@ -75,10 +105,13 @@ For documentation-only changes:
 ```sh
 python tools/update_docs_supported_commands.py --check
 python -m py_compile tools/update_docs_supported_commands.py
-git diff --check -- README.md docs/*.md docs/assets/*.svg tools/*.py .pre-commit-config.yaml .gitlab-ci.yml
+git diff --check -- README.md docs/*.md docs/assets/*.svg tools/*.py .pre-commit-config.yaml
 ```
 
-For code changes, add the nearest static or pytest check from
-[Testing and debugging](testing_and_debugging.md). GPU, Docker, TensorRT,
-private checkpoint, and dataset-heavy tests should be called out explicitly
-when they are outside the change's blast radius.
+For code changes, run the same static checks CI runs (`pre-commit run` on the
+changed files; refer to [Testing and debugging](testing_and_debugging.md)),
+then the nearest pytest suite. Call out GPU, Docker, TensorRT, private
+checkpoint, and dataset-heavy tests explicitly when they fall outside the
+change's blast radius.
+
+All commits need a DCO sign-off (`git commit -s`); CI enforces it.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,18 +1,60 @@
 # Architecture
 
-This guide explains the runtime and source-code flow for TAO Deploy model
-families: how a console command reaches a script, how configuration is
-validated, and how the shared TensorRT runtime is layered. For a directory-level
-orientation, read the [Codebase tour](codebase_tour.md) first.
+This guide explains what TAO Deploy is, how customers run it, and how a command
+flows through the source code. For a directory-level orientation, read the
+[Codebase tour](codebase_tour.md) first.
 
-![TAO Deploy source runtime flow](assets/source_runtime_flow.svg)
+## What TAO Deploy Is
 
-TAO Deploy is a deployment runtime repository, not a training repository. Every
-command accepts an exported model (ONNX or encrypted ETLT), builds or loads a
-TensorRT engine, runs inference or evaluation, and writes outputs under a
-results directory.
+TAO Deploy is the TensorRT backend of the TAO ecosystem: it takes models
+exported by tao-pytorch (ONNX or encrypted ETLT), builds optimized TensorRT
+engines, and runs engine-based inference and evaluation. This repository is its
+source. It ships to users as one container,
+`nvcr.io/nvidia/tao/tao-toolkit:<version>-deploy`, alongside the sibling
+backends built from tao-pytorch (training) and tao-dataservices (dataset
+preparation).
+
+The product surface is the set of per-model console commands this package
+installs (`dino`, `rtdetr`, `grounding_dino`, and so on — 39 in total) with
+their `gen_trt_engine`, `evaluate`, and `inference` subtasks. This is a
+deployment runtime repository, not a training repository.
+
+## How Users Run TAO Deploy
+
+As of TAO 7.0 there is one supported user surface, with the container CLI
+underneath it:
+
+1. **Agent and TAO skills (current).** Users load the `tao-skills` plugin in a
+   coding agent and ask for the outcome ("build an INT8 engine from this DINO
+   export"). The skills and the TAO Execution SDK dispatch a job to the user's
+   compute backend, which runs the deploy container and invokes the console
+   commands documented here.
+2. **Container CLI (the layer underneath).** Inside the `<version>-deploy`
+   container: `dino gen_trt_engine -e spec.yaml`, `dino evaluate -e spec.yaml`,
+   `dino inference -e spec.yaml`.
+
+Two older surfaces were **removed in TAO 7.0**: the **TAO Launcher**
+(`tao deploy <network> <verb>`, deprecated in 6.0) and **FTMS** (the
+Fine-Tuning MicroService REST API plus `nvidia-tao-client`). This repository
+still contains FTMS-era code paths (the microservice `CMD` in the release
+Dockerfile, `JOB_ID`-gated log teeing, the config field metadata consumed by
+the FTMS specification UI); treat them as legacy integration surfaces.
+
+## Terminology
+
+| Term | Meaning here |
+| :--- | :--- |
+| Model family | One deployable network with its own console command and package under `cv/` or `multimodal/`, such as `dino`. |
+| Subtask | One operation of a family, implemented as one module in its `scripts/` package: `dino gen_trt_engine`. |
+| Specification (spec) | The YAML experiment file passed with `-e`, validated against the family's dataclass schema. |
+| Entry point styles | The three in-repo dispatch mechanisms under `cv/common/entrypoint/` (Hydra, proto, agnostic). Internal code, not a product. |
+| `tao_deploy` | The **development-only** container launcher defined by `scripts/envsetup.sh` (a shell function over `runner/tao_deploy.py`). Users never see it. |
+| TAO Launcher | The removed `tao` CLI product (deprecated 6.0, removed 7.0). Not related to `tao_deploy` or the entry point code above. |
+| FTMS | The removed Fine-Tuning MicroService REST API and `nvidia-tao-client`. Its in-repo remnants are noted above. |
 
 ## Command Runtime Flow
+
+![TAO Deploy source runtime flow](assets/source_runtime_flow.svg)
 
 `setup.py` registers each installed command:
 
@@ -174,9 +216,10 @@ For local development the submodule is mounted with the checkout at
 `/workspace/tao-deploy/tao-core`, and the launcher's `PYTHONPATH` setup makes
 `nvidia_tao_core` importable from there.
 
-## Container Flow
+## Container Flow (Development Only)
 
-Source development usually starts with:
+`tao_deploy` is the development launcher (refer to Terminology); users never
+see it. Source development usually starts with:
 
 ```sh
 source scripts/envsetup.sh

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,70 +1,178 @@
 # Architecture
 
+This guide explains the runtime and source-code flow for TAO Deploy model
+families: how a console command reaches a script, how configuration is
+validated, and how the shared TensorRT runtime is layered. For a directory-level
+orientation, read the [Codebase tour](codebase_tour.md) first.
+
 ![TAO Deploy source runtime flow](assets/source_runtime_flow.svg)
 
-TAO Deploy is organized around installed task commands. Each command dispatches
-to model-specific scripts that build TensorRT engines, run inference, evaluate
-outputs, or generate default specs.
+TAO Deploy is a deployment runtime repository, not a training repository. Every
+command accepts an exported model (ONNX or encrypted ETLT), builds or loads a
+TensorRT engine, runs inference or evaluation, and writes outputs under a
+results directory.
 
-## Command Flow
+## Command Runtime Flow
 
-1. `setup.py` declares console scripts such as `dino`, `classification_tf1`,
-   `model_agnostic`, and `clip`.
-2. Each console script imports a model entrypoint under
-   `nvidia_tao_deploy/cv/MODEL_NAME/entrypoint/` or
-   `nvidia_tao_deploy/multimodal/MODEL_NAME/entrypoint/`.
-3. Newer commands use `nvidia_tao_deploy.cv.common.entrypoint.entrypoint_hydra`.
-   The entrypoint discovers Python files in the model `scripts/` package,
-   accepts a subtask name, accepts `-e/--experiment_spec_file` for normal
-   subtasks, and dispatches to the selected script.
-4. Older commands use `entrypoint_proto.launch_job`. Those scripts define their
-   own `build_command_line_parser()` functions and generally consume proto-style
-   experiment specs.
-5. Script modules call common helpers such as `decode_model()`,
-   `initialize_gen_trt_engine_experiment()`, model-specific `EngineBuilder`
-   classes, and `TRTInferencer` subclasses.
-6. Status logging and telemetry are handled by decorators and shared entrypoint
-   code, while results are written under the configured results directory.
+`setup.py` registers each installed command:
 
-`model_agnostic` is a special command. It reads `model_name` from the experiment
-spec, imports that model's scripts package, and then delegates to the same
-Hydra-style launch path.
+```text
+dino=nvidia_tao_deploy.cv.dino.entrypoint.dino:main
+```
+
+There are three entry point styles, all in
+`nvidia_tao_deploy/cv/common/entrypoint/`:
+
+| Style | Module | Used by |
+| :--- | :--- | :--- |
+| Hydra (modern) | `entrypoint_hydra.py` | 21 CV families plus `clip` and `video_clip`. YAML specs validated against dataclass schemas. |
+| Proto (legacy) | `entrypoint_proto.py` | 12 TF1-era families. Protobuf text specs; each script defines `build_command_line_parser()`. |
+| Agnostic | `entrypoint_agnostic.py` | The `model_agnostic` command. Reads `model_name` from the spec, imports that family's scripts, then delegates to the Hydra path. |
+
+The Hydra entrypoint (`entrypoint_hydra.py`) does the following:
+
+1. `get_subtasks(<model>.scripts)` walks the scripts package with `pkgutil`
+   and records each module as a subtask, then injects the synthetic
+   `default_specs` subtask (implemented in
+   `cv/common/spec_utils/default_specs.py`).
+2. `command_line_parser()` validates the positional subtask and
+   `-e/--experiment_spec_file`.
+3. `launch()` converts the spec path into `--config-path <dir>` and
+   `--config-name <file>`, forwards unknown CLI tokens verbatim as Hydra
+   overrides, resolves the GPU ID into `CUDA_VISIBLE_DEVICES`, and spawns the
+   selected script as a **fresh Python subprocess**, teeing stdout (and to
+   `$TAO_MICROSERVICES_TTY_LOG/$JOB_ID/microservices_log.txt` when `JOB_ID` is
+   set). It then reports telemetry and exits with the child's status.
+
+`launch()` intentionally clamps execution to one GPU; it parses `num_gpus` and
+`gpu_ids` and then reduces them to a single device.
+
+Inside the child process, every Hydra-style script has the same shape:
+
+```python
+@hydra_runner(config_path=os.path.join(spec_root, "specs"),
+              config_name="gen_trt_engine", schema=ExperimentConfig)
+@monitor_status(name="dino", mode="gen_trt_engine")
+def main(cfg: ExperimentConfig) -> None:
+    ...
+```
+
+`hydra_runner` (`cv/common/hydra/hydra_runner.py`) registers the schema in
+Hydra's `ConfigStore` and suppresses Hydra's output directories.
+`monitor_status` (`cv/common/decorators.py`) creates the results directory,
+dumps the resolved configuration to `<results_dir>/experiment.yaml`, writes structured
+progress to `<results_dir>/status.json`, and maps exception classes to
+user-facing status messages that the entrypoint matches for telemetry.
 
 ## Configuration Flow
 
-Hydra-style deploy backends use two source areas:
+![TAO Deploy configuration flow](assets/config_flow.svg)
+
+Hydra-style families use two source areas:
 
 | Source | Role |
 | :--- | :--- |
-| `nvidia_tao_deploy/config/MODEL_NAME/default_config.py` | Structured dataclass schema for the model. |
-| `nvidia_tao_deploy/cv/MODEL_NAME/specs/*.yaml` | Runtime spec templates named by each script's `hydra_runner(config_name=...)`. |
+| `nvidia_tao_deploy/config/<model>/default_config.py` | Structured dataclass schema. Always defines `ExperimentConfig`, usually extending `CommonExperimentConfig` from `config/common/common_config.py`. |
+| `nvidia_tao_deploy/cv/<model>/specs/*.yaml` | Default spec templates, named by each script's `hydra_runner(config_name=...)`. |
 
-The subtask name and the YAML filename are not always identical. For example,
-DINO exposes an `inference` subtask while `nvidia_tao_deploy/cv/dino/scripts/inference.py`
-uses `config_name="infer"`, so the default template is `infer.yaml`.
+The configuration precedence at runtime is:
 
-Legacy TF1-style and some older CV commands keep proto files under the model
-package and build argparse parsers in each script. Those commands should be
-extended in their existing style unless a broader migration is planned.
+```text
+dataclass defaults -> spec YAML (-e) -> command-line Hydra overrides
+```
+
+Schemas declare their fields through typed factories from
+`config/utils/types.py` (`STR_FIELD`, `INT_FIELD`, `FLOAT_FIELD`, `BOOL_FIELD`,
+`LIST_FIELD`, `DICT_FIELD`, `DATACLASS_FIELD`, ...). Each factory attaches
+metadata (`description`, `display_name`, `valid_options`, `valid_min`,
+`valid_max`, and `default_value`) that powers specification generation and the
+FTMS/API specification UI. The metadata `default_value` and the dataclass
+default `value` are separate and can differ.
+
+Shared configuration bases in `config/common/common_config.py` include
+`CommonExperimentConfig`, `GenTrtEngineConfig`, `TrtConfig`, and
+`CalibrationConfig`; deploy schemas mirror the training-side schemas in
+tao-pytorch, and `tests/core/test_backbone_schema_drift.py` guards selected
+mirrors against drifting.
+
+**The subtask name and the specification template name are not always identical.** The
+source of truth is each script's `hydra_runner(config_name=...)`:
+
+| Pattern | Families |
+| :--- | :--- |
+| `inference.py` -> `config_name="infer"` | centerpose, deformable_detr, dino, grounding_dino, mask_grounding_dino, rtdetr, segformer, depth_net, mask2former, oneformer, visual_changenet |
+| One shared spec for all subtasks | classification_tf2, efficientdet_tf2 (`experiment_spec`), ocrnet, optical_inspection (`experiment`) |
+| `gen_trt_engine.py` -> `config_name="export"` | segformer, ml_recog |
+| `evaluate.py` -> `config_name="infer"` | mask2former, oneformer, segformer |
+| No matching default template (subtask requires `-e`) | ml_recog `gen_trt_engine`, all depth_net subtasks, all visual_changenet subtasks |
+
+Legacy proto families keep `.proto` definitions and checked-in `*_pb2.py`
+under `<model>/proto/` and parse text specifications in each script. Extend those
+families in their existing style unless a broader migration is planned.
+
+Generate a default specification for a Hydra family with:
+
+```sh
+<model> default_specs results_dir=/tmp/<model>_specs
+```
 
 ## TensorRT Runtime
 
-The shared runtime is concentrated in:
+The shared runtime has three layers: build, execute, and evaluate.
+
+```text
+decode_model()                      # utils/decoding.py: .etlt/.onnx/.uff -> ONNX bytes
+  -> EngineBuilder.create_network() # engine/builder.py: parse ONNX, build optimization profile
+  -> EngineBuilder.create_engine()  # precision flags, INT8 calibration, serialize .engine
+  -> TRTInferencer                  # inferencer/trt_inferencer.py: load engine, allocate buffers
+  -> dataloader + metrics           # evaluate: batches + GT -> mAP/AP/mIoU
+```
 
 | Path | Responsibility |
 | :--- | :--- |
-| `nvidia_tao_deploy/engine/builder.py` | Base `EngineBuilder` behavior for parsing ONNX/UFF/ETLT and creating engines. |
-| `nvidia_tao_deploy/engine/calibrator.py` and `tensorfile_calibrator.py` | INT8 calibration support. |
-| `nvidia_tao_deploy/inferencer/trt_inferencer.py` | Base TensorRT execution wrapper. |
-| `nvidia_tao_deploy/utils/decoding.py` | Encrypted model decoding. |
-| `nvidia_tao_deploy/utils/image_batcher.py` | Image batching for inference. |
-| `nvidia_tao_deploy/dataloader/` | Shared dataset readers. |
-| `nvidia_tao_deploy/metrics/` | KITTI, COCO, and segmentation metrics. |
+| `engine/builder.py` | `EngineBuilder` (abstract base): ONNX parsing, dynamic-axis optimization profiles, precision selection (`fp32/fp16/bf16/int8`, strongly typed for QDQ-quantized ONNX), per-layer precision, timing cache, and engine serialization. |
+| `engine/calibrator.py` | `EngineCalibrator`: INT8 post-training calibration driven by an `ImageBatcher` over a calibration image directory. |
+| `engine/tensorfile_calibrator.py` | `TensorfileCalibrator`: legacy INT8 calibration from `.tensorfile` (HDF5) archives. |
+| `inferencer/base_inferencer.py` | `BaseInferencer` abstract contract (`load_model`, `infer`, drawing helpers). |
+| `inferencer/trt_inferencer.py` | `TRTInferencer`: engine deserialization, I/O tensor discovery (exposed as `Tensor`/`InputTensor` objects from `types/tensors.py`), and the execute loop. |
+| `inferencer/utils.py` | `HostDeviceMem`, `allocate_buffers()`, `do_inference()`. |
+| `utils/decoding.py` | `decode_model()` dispatches on extension; `.etlt` payloads are decrypted and identified as ONNX or UFF. |
+| `utils/image_batcher.py` | `ImageBatcher`: directory to batched arrays with named preprocessing modes; used by both inference and INT8 calibration. |
+| `dataloader/` | `COCOLoader` and KITTI/ADE20K/COCO-panoptic readers pairing preprocessed batches with ground truth. |
+| `metrics/` | COCO mAP (pycocotools), KITTI AP, semantic-segmentation mIoU. |
 
-Model packages add specialized builders and inferencers when the generic
-runtime is not enough. DINO reuses D-DETR builder and inferencer classes, CLIP
-adds multimodal engine and inferencer support, and proto-era models often keep
-their builders beside the model package.
+Model families specialize this runtime by subclassing: the repository has roughly 22
+`EngineBuilder` subclasses and 29 `TRTInferencer` subclasses. Families
+frequently share a sibling's classes: `dino` reuses the `deformable_detr`
+builder, inferencer, and dataloader, and `rtdetr` reuses its builder and
+inferencer. Legacy UFF/plugin-era
+families override `create_network()`; on TensorRT >= 9 the UFF paths raise
+`NotImplementedError`, so those families are ONNX/ETLT-ONNX only on current
+base images.
+
+Calibration configuration is validated centrally in
+`cv/common/initialize_experiments.py::initialize_gen_trt_engine_experiment()`,
+which checks calibration batch math and image counts, parses
+`layers_precision` entries, and returns the kwarg dicts that every Hydra
+`gen_trt_engine.py` unpacks into its builder.
+
+## TAO Core Boundary
+
+`tao-core/` is a git submodule providing shared TAO infrastructure. TAO Deploy
+consumes it three ways:
+
+* **Status callbacks:** `cv/common/logging/status_logging.py` imports from
+  `nvidia_tao_core.microservices` (unguarded — the submodule must be
+  initialized or every command fails at import).
+* **Telemetry:** both entrypoints soft-import
+  `nvidia_tao_core.telemetry` and degrade gracefully without it.
+* **Release container:** `release/docker/Dockerfile.release` builds and
+  installs the tao-core wheel and uses tao-core's microservice app as the
+  container entrypoint.
+
+For local development the submodule is mounted with the checkout at
+`/workspace/tao-deploy/tao-core`, and the launcher's `PYTHONPATH` setup makes
+`nvidia_tao_core` importable from there.
 
 ## Container Flow
 
@@ -75,10 +183,22 @@ source scripts/envsetup.sh
 tao_deploy --gpus all
 ```
 
-`scripts/envsetup.sh` sets `NV_TAO_DEPLOY_TOP` and defines the shell function.
-`runner/tao_deploy.py` reads `docker/manifest.json`, selects the x86 or ARM
-digest from the host architecture, pulls the base image if needed, mounts the
-source checkout into `/workspace/tao-deploy`, and runs the requested command.
+`scripts/envsetup.sh` sets `NV_TAO_DEPLOY_TOP`, defines the `tao_deploy` shell
+function, and installs the repository's git hooks. `runner/tao_deploy.py` reads
+`docker/manifest.json`, selects the x86 or ARM digest from the host
+architecture, pulls the base image if needed, mounts the source checkout at
+`/workspace/tao-deploy`, and runs the requested command.
 
-See [Container power users](container_power_users.md) for direct Docker
+Refer to [Container power users](container_power_users.md) for direct Docker
 equivalents and troubleshooting.
+
+## Cross-Repository Contract
+
+A model family in TAO Deploy consumes what the matching family in tao-pytorch
+exports. When changing either side, verify:
+
+* The export configuration fields in tao-pytorch align with what the deploy
+  schema in `nvidia_tao_deploy/config/<model>/` expects.
+* The input names, shapes, and dynamic axes assumed by the deploy engine
+  builder and dataloader match the exported ONNX.
+* The console command exists on both sides with consistent subtask naming.

--- a/docs/assets/config_flow.svg
+++ b/docs/assets/config_flow.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="940" height="330" viewBox="0 0 940 330" role="img" aria-labelledby="title desc">
+  <title id="title">TAO Deploy configuration flow</title>
+  <desc id="desc">Configuration flows from dataclass defaults to spec YAML to Hydra overrides and into deploy scripts.</desc>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#475569"/>
+    </marker>
+    <style>
+      .box { fill: #f8fafc; stroke: #334155; stroke-width: 1.5; rx: 10; }
+      .schema { fill: #eef2ff; stroke: #4f46e5; stroke-width: 1.7; rx: 10; }
+      .runtime { fill: #ecfdf5; stroke: #047857; stroke-width: 1.7; rx: 10; }
+      .label { font: 600 15px Arial, sans-serif; fill: #111827; }
+      .small { font: 12px Arial, sans-serif; fill: #374151; }
+      .path { stroke: #475569; stroke-width: 2; fill: none; marker-end: url(#arrow); }
+      .merge { stroke: #94a3b8; stroke-width: 1.5; stroke-dasharray: 5 4; fill: none; }
+    </style>
+  </defs>
+
+  <text x="470" y="30" text-anchor="middle" class="label">Configuration Flow</text>
+
+  <rect x="45" y="82" width="170" height="78" class="schema"/>
+  <text x="130" y="108" text-anchor="middle" class="label">Dataclass schema</text>
+  <text x="130" y="130" text-anchor="middle" class="small">config/&lt;model&gt;</text>
+  <text x="130" y="147" text-anchor="middle" class="small">defaults + metadata</text>
+
+  <rect x="275" y="82" width="170" height="78" class="box"/>
+  <text x="360" y="108" text-anchor="middle" class="label">Spec YAML (-e)</text>
+  <text x="360" y="130" text-anchor="middle" class="small">cv/&lt;model&gt;/specs</text>
+  <text x="360" y="147" text-anchor="middle" class="small">named by config_name</text>
+
+  <rect x="505" y="82" width="170" height="78" class="box"/>
+  <text x="590" y="108" text-anchor="middle" class="label">Hydra overrides</text>
+  <text x="590" y="130" text-anchor="middle" class="small">gen_trt_engine.gpu_id=0</text>
+  <text x="590" y="147" text-anchor="middle" class="small">CLI dotlist</text>
+
+  <rect x="735" y="82" width="160" height="78" class="runtime"/>
+  <text x="815" y="108" text-anchor="middle" class="label">ExperimentConfig</text>
+  <text x="815" y="130" text-anchor="middle" class="small">cfg passed to</text>
+  <text x="815" y="147" text-anchor="middle" class="small">script main(cfg)</text>
+
+  <rect x="275" y="230" width="170" height="58" class="runtime"/>
+  <text x="360" y="255" text-anchor="middle" class="label">default_specs</text>
+  <text x="360" y="275" text-anchor="middle" class="small">generated YAML</text>
+
+  <rect x="735" y="230" width="160" height="58" class="runtime"/>
+  <text x="815" y="255" text-anchor="middle" class="label">Deploy code</text>
+  <text x="815" y="275" text-anchor="middle" class="small">builder/inferencer</text>
+
+  <path d="M215 121 H275" class="path"/>
+  <path d="M445 121 H505" class="path"/>
+  <path d="M675 121 H735" class="path"/>
+  <path d="M130 160 V259 H275" class="path"/>
+  <path d="M815 160 V230" class="path"/>
+  <path d="M215 121 C240 55 480 55 505 121" class="merge"/>
+  <path d="M445 121 C470 188 710 188 735 121" class="merge"/>
+</svg>

--- a/docs/assets/module_map.svg
+++ b/docs/assets/module_map.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="520" viewBox="0 0 980 520" role="img" aria-labelledby="title desc">
+  <title id="title">TAO Deploy package module map</title>
+  <desc id="desc">The nvidia_tao_deploy package groups model families over shared entrypoint, config, engine, inferencer, dataloader, metrics, and utility modules.</desc>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#475569"/>
+    </marker>
+    <style>
+      .zone { fill: #f8fafc; stroke: #94a3b8; stroke-width: 1.2; stroke-dasharray: 6 4; rx: 12; }
+      .box { fill: #ffffff; stroke: #334155; stroke-width: 1.5; rx: 10; }
+      .family { fill: #eef2ff; stroke: #4f46e5; stroke-width: 1.7; rx: 10; }
+      .shared { fill: #ecfdf5; stroke: #047857; stroke-width: 1.7; rx: 10; }
+      .config { fill: #fef3c7; stroke: #b45309; stroke-width: 1.7; rx: 10; }
+      .label { font: 600 15px Arial, sans-serif; fill: #111827; }
+      .small { font: 12px Arial, sans-serif; fill: #374151; }
+      .zonelabel { font: 700 13px Arial, sans-serif; fill: #64748b; letter-spacing: 1px; }
+      .path { stroke: #475569; stroke-width: 2; fill: none; marker-end: url(#arrow); }
+    </style>
+  </defs>
+
+  <text x="490" y="28" text-anchor="middle" class="label">nvidia_tao_deploy Module Map</text>
+
+  <rect x="30" y="50" width="920" height="150" class="zone"/>
+  <text x="50" y="72" class="zonelabel">MODEL FAMILIES</text>
+
+  <rect x="55" y="90" width="270" height="90" class="family"/>
+  <text x="190" y="114" text-anchor="middle" class="label">cv/&lt;model&gt;/ (33 families)</text>
+  <text x="190" y="134" text-anchor="middle" class="small">entrypoint/  scripts/  specs/</text>
+  <text x="190" y="151" text-anchor="middle" class="small">optional: engine_builder.py,</text>
+  <text x="190" y="167" text-anchor="middle" class="small">inferencer.py, dataloader.py, proto/</text>
+
+  <rect x="360" y="90" width="230" height="90" class="family"/>
+  <text x="475" y="114" text-anchor="middle" class="label">multimodal/&lt;model&gt;/</text>
+  <text x="475" y="134" text-anchor="middle" class="small">clip, video_clip</text>
+  <text x="475" y="151" text-anchor="middle" class="small">same entrypoint/scripts/specs</text>
+  <text x="475" y="167" text-anchor="middle" class="small">shape as cv families</text>
+
+  <rect x="625" y="90" width="300" height="90" class="config"/>
+  <text x="775" y="114" text-anchor="middle" class="label">config/&lt;model&gt;/</text>
+  <text x="775" y="134" text-anchor="middle" class="small">default_config.py :: ExperimentConfig</text>
+  <text x="775" y="151" text-anchor="middle" class="small">config/common: shared bases</text>
+  <text x="775" y="167" text-anchor="middle" class="small">config/utils/types.py: *_FIELD factories</text>
+
+  <rect x="30" y="220" width="920" height="140" class="zone"/>
+  <text x="50" y="242" class="zonelabel">SHARED COMMAND INFRASTRUCTURE</text>
+
+  <rect x="55" y="258" width="330" height="84" class="shared"/>
+  <text x="220" y="282" text-anchor="middle" class="label">cv/common/entrypoint/</text>
+  <text x="220" y="302" text-anchor="middle" class="small">entrypoint_hydra (modern), entrypoint_proto</text>
+  <text x="220" y="319" text-anchor="middle" class="small">(legacy), entrypoint_agnostic (model_agnostic)</text>
+
+  <rect x="415" y="258" width="250" height="84" class="shared"/>
+  <text x="540" y="282" text-anchor="middle" class="label">cv/common/</text>
+  <text x="540" y="302" text-anchor="middle" class="small">hydra_runner, monitor_status,</text>
+  <text x="540" y="319" text-anchor="middle" class="small">initialize_experiments, status logging</text>
+
+  <rect x="695" y="258" width="230" height="84" class="shared"/>
+  <text x="810" y="282" text-anchor="middle" class="label">utils/ + types/</text>
+  <text x="810" y="302" text-anchor="middle" class="small">decode_model, ImageBatcher,</text>
+  <text x="810" y="319" text-anchor="middle" class="small">Tensor / InputTensor</text>
+
+  <rect x="30" y="380" width="920" height="120" class="zone"/>
+  <text x="50" y="402" class="zonelabel">TENSORRT RUNTIME + EVALUATION</text>
+
+  <rect x="55" y="416" width="270" height="68" class="shared"/>
+  <text x="190" y="440" text-anchor="middle" class="label">engine/</text>
+  <text x="190" y="460" text-anchor="middle" class="small">EngineBuilder, INT8 calibrators</text>
+
+  <rect x="360" y="416" width="270" height="68" class="shared"/>
+  <text x="495" y="440" text-anchor="middle" class="label">inferencer/</text>
+  <text x="495" y="460" text-anchor="middle" class="small">TRTInferencer, buffers, do_inference</text>
+
+  <rect x="665" y="416" width="260" height="68" class="shared"/>
+  <text x="795" y="440" text-anchor="middle" class="label">dataloader/ + metrics/</text>
+  <text x="795" y="460" text-anchor="middle" class="small">COCO/KITTI/ADE readers, mAP/mIoU</text>
+
+  <path d="M190 180 V258" class="path"/>
+  <path d="M475 180 V258" class="path"/>
+  <path d="M775 180 L775 230 L665 258" class="path"/>
+  <path d="M190 342 V416" class="path"/>
+  <path d="M495 342 V416" class="path"/>
+  <path d="M795 342 V416" class="path"/>
+</svg>

--- a/docs/codebase_tour.md
+++ b/docs/codebase_tour.md
@@ -1,0 +1,193 @@
+# Codebase Tour
+
+This is a guided walk through the TAO Deploy repository for developers picking
+up the codebase for the first time. It answers three questions: what each
+directory is for, how the Python package is organized into modules, and where
+the sharp edges are. For the runtime and data-flow view, read
+[Architecture](architecture.md) next.
+
+![TAO Deploy module map](assets/module_map.svg)
+
+## Repository Layout
+
+```text
+tao-deploy/
+├── nvidia_tao_deploy/        # The installable Python package (everything shipped in the wheel)
+│   ├── cv/                   # 33 model families + cv/common shared entrypoint infra
+│   ├── multimodal/           # clip, video_clip model families
+│   ├── config/               # Hydra dataclass schemas, one package per model family
+│   ├── engine/               # TensorRT engine building and INT8 calibration
+│   ├── inferencer/           # TensorRT execution wrappers (buffers, bindings, infer loop)
+│   ├── dataloader/           # Shared dataset readers (COCO, KITTI, ADE20K, COCO-panoptic)
+│   ├── metrics/              # COCO mAP, KITTI AP, semantic-segmentation mIoU
+│   ├── utils/                # Model decoding (.etlt/.onnx), image batching, path helpers
+│   └── types/                # Tensor / InputTensor value objects used by inferencers
+├── runner/tao_deploy.py      # Host-side Docker launcher (not shipped in the wheel)
+├── scripts/envsetup.sh       # Defines the tao_deploy shell function; installs git hooks
+├── docker/                   # Base development image: Dockerfile, manifest.json, requirements
+├── release/                  # Release image, version metadata (release/python/version.py)
+├── internal/                 # Maintainer-only helpers (proto regeneration, ONNX encrypt/decrypt)
+├── tools/                    # update_docs_supported_commands.py (generates supported_commands.md)
+├── tests/                    # pytest suites, one directory per covered model family plus tests/core
+├── docs/                     # This documentation
+├── .github/                  # GitHub Actions workflows and shared hook scripts
+├── tao-core/                 # Git submodule: shared TAO config/microservice/telemetry code
+├── setup.py                  # Package definition and console_scripts (one per model command)
+└── Makefile                  # Wheel build targets (build, build_l4t, install, clean)
+```
+
+The rules of thumb are:
+
+* If it ships to users, it lives under `nvidia_tao_deploy/`.
+* If it launches or builds containers, it lives in `runner/`, `docker/`, or
+  `release/`.
+* If it validates the repository, it lives in `tests/`, `.pre-commit-config.yaml`, or
+  `.github/workflows/`.
+
+## The Package in One Table
+
+| Module | Role | Key files |
+| :--- | :--- | :--- |
+| `cv/<model>/` | One deployable model family: entrypoint, subtask scripts, spec templates, and any model-specific builder/inferencer/dataloader. | `entrypoint/<model>.py`, `scripts/*.py`, `specs/*.yaml` |
+| `cv/common/` | Shared command infrastructure: the three entrypoint styles, the Hydra runner, status logging, telemetry, and experiment initialization. | `entrypoint/entrypoint_hydra.py`, `entrypoint/entrypoint_proto.py`, `entrypoint/entrypoint_agnostic.py`, `hydra/hydra_runner.py`, `decorators.py`, `initialize_experiments.py` |
+| `multimodal/<model>/` | Same shape as `cv/<model>/` for CLIP-style models. | `clip/`, `video_clip/` |
+| `config/<model>/` | Structured dataclass schema mirrored from the training side. | `default_config.py` (always defines `ExperimentConfig`) |
+| `config/common/` | Shared config bases every model extends. | `common_config.py` (`CommonExperimentConfig`, `GenTrtEngineConfig`, `TrtConfig`, `CalibrationConfig`) |
+| `config/utils/` | Typed field factories that attach UI/validation metadata. | `types.py` (`STR_FIELD`, `INT_FIELD`, `DATACLASS_FIELD`, ...) |
+| `engine/` | ONNX/UFF parsing, optimization profiles, precision selection, engine serialization, INT8 calibration. | `builder.py` (`EngineBuilder`), `calibrator.py`, `tensorfile_calibrator.py` |
+| `inferencer/` | Engine loading, I/O tensor discovery, host/device buffers, the infer loop. | `base_inferencer.py`, `trt_inferencer.py` (`TRTInferencer`), `utils.py` (`allocate_buffers`, `do_inference`) |
+| `dataloader/` | Batch iterators that pair preprocessed images with ground truth for evaluation. | `coco.py` (`COCOLoader`), `kitti.py`, `ade.py`, `coco_panoptic.py` |
+| `metrics/` | Metric computation for `evaluate` subtasks. | `coco_metric.py`, `kitti_metric.py`, `semantic_segmentation_metric.py` |
+| `utils/` | Cross-cutting helpers. | `decoding.py` (`decode_model`), `image_batcher.py` (`ImageBatcher`) |
+| `types/` | Typed views over engine bindings. | `tensors.py` (`Tensor`, `InputTensor`) |
+
+## Model Family Inventory
+
+Every family has the same skeleton — `entrypoint/<name>.py`, `scripts/`, and
+`specs/` — but the repository contains two generations of command plumbing, and which
+one a family uses is the single most important thing to know before editing it.
+
+**Hydra-style (modern: YAML specifications, dataclass schemas under `config/`):**
+`centerpose`, `classification_pyt`, `classification_tf2`, `deformable_detr`,
+`depth_net`, `dino`, `efficientdet_tf2`, `grounding_dino`, `mae`,
+`mask2former`, `mask_grounding_dino`, `ml_recog`, `nvdinov2`, `ocdnet`,
+`ocrnet`, `oneformer`, `optical_inspection`, `pointpillars`, `rtdetr`,
+`segformer`, `visual_changenet`, plus `multimodal/clip` and
+`multimodal/video_clip`.
+
+**Proto-style (legacy: protobuf text specifications, `proto/` package per family):**
+`classification_tf1`, `detectnet_v2`, `efficientdet_tf1`, `faster_rcnn`,
+`lprnet`, `mask_rcnn`, `multitask_classification`, `retinanet`, `ssd`, `unet`,
+`yolo_v3`, `yolo_v4`.
+
+Quick way to tell them apart: a Hydra family has a mirror package under
+`nvidia_tao_deploy/config/<name>/`; a proto family has a `proto/` directory with
+checked-in `*_pb2.py` files instead (regenerated by hand with
+`internal/generate_pb2.sh <name>`).
+
+Naming quirks to expect: `ml_recog` (source directory) is tested under
+`tests/metric_learning_recognition/`; `classification_tf1`,
+`classification_tf2`, and `classification_pyt` are three unrelated families;
+`dssd` and `yolo_v4_tiny` are console-script aliases for `ssd` and `yolo_v4`.
+
+## Anatomy of One Family: `dino`
+
+```text
+nvidia_tao_deploy/cv/dino/
+├── entrypoint/dino.py            # ~35 lines: argparse shell over entrypoint_hydra
+├── scripts/gen_trt_engine.py     # ONNX/ETLT -> .engine
+├── scripts/evaluate.py           # engine + COCO dataset -> mAP
+├── scripts/inference.py          # engine + image dir -> annotated images + labels
+└── specs/{gen_trt_engine,evaluate,infer}.yaml
+nvidia_tao_deploy/config/dino/
+├── default_config.py             # ExperimentConfig (top-level schema)
+└── {dataset,model,train,deploy}.py
+```
+
+Notice what is *missing*: DINO has no builder, inferencer, or dataloader of its
+own. It reuses `deformable_detr`'s — `DDETRDetEngineBuilder`,
+`DDETRInferencer`, and `DDETRCOCOLoader` in
+`nvidia_tao_deploy/cv/deformable_detr/`. `rtdetr` reuses the builder and
+inferencer the same way. Sharing a sibling family's runtime classes is a
+normal, encouraged pattern; check for an existing builder before writing a new
+one.
+
+Command flow for `dino gen_trt_engine -e spec.yaml`:
+
+1. The `dino` console script (registered in `setup.py`) calls
+   `cv/dino/entrypoint/dino.py:main`.
+2. `entrypoint_hydra.get_subtasks()` discovers `scripts/*.py` as subtasks and
+   injects the synthetic `default_specs` subtask.
+3. `entrypoint_hydra.launch()` converts `-e` into Hydra `--config-path` and
+   `--config-name` flags, sets `CUDA_VISIBLE_DEVICES`, and **spawns a fresh
+   `python .../scripts/gen_trt_engine.py` subprocess**.
+4. Inside the child, `@hydra_runner(..., schema=ExperimentConfig)` validates the
+   YAML against the dataclass schema, and `@monitor_status(...)` creates the
+   results dir, dumps the resolved configuration, and writes `status.json`.
+5. The script body decodes the model (`decode_model`), builds the engine
+   (`DDETRDetEngineBuilder.create_network()` then `create_engine()`), and
+   serializes the plan to `gen_trt_engine.trt_engine`.
+
+The subprocess step matters for debugging: breakpoints set in a `scripts/*.py`
+are never hit when you launch via the console command. Run the script module
+directly with `--config-path`/`--config-name` to debug it in-process.
+
+## Where Shared Behavior Lives
+
+| Behavior | Implementation |
+| :--- | :--- |
+| Subtask discovery, `default_specs` injection | `cv/common/entrypoint/entrypoint_hydra.py::get_subtasks` |
+| Spec-file to Hydra flag translation, GPU selection, subprocess launch, telemetry | `cv/common/entrypoint/entrypoint_hydra.py::launch` |
+| Legacy argparse dispatch | `cv/common/entrypoint/entrypoint_proto.py::launch_job` |
+| `model_agnostic` command (reads `model_name` from the spec) | `cv/common/entrypoint/entrypoint_agnostic.py` |
+| Schema registration and Hydra invocation | `cv/common/hydra/hydra_runner.py` |
+| Results dir creation, config dump, `status.json`, error classification | `cv/common/decorators.py::monitor_status` |
+| Calibration config validation, builder/engine kwarg assembly | `cv/common/initialize_experiments.py::initialize_gen_trt_engine_experiment` |
+| Encrypted model decode (`.etlt` vs `.onnx` vs `.uff`) | `utils/decoding.py::decode_model` |
+
+## Sharp Edges
+
+The following behaviors surprise every new developer; they are collected in one place:
+
+* **The `tao-core` submodule is required at import time.**
+  `cv/common/logging/status_logging.py` imports from `nvidia_tao_core`
+  unguarded, so with an uninitialized submodule essentially every command dies
+  on import. Run `git submodule update --init` first; `scripts/envsetup.sh`
+  puts `tao-core/` on `PYTHONPATH` for containers.
+* **Subtask name and specification template name diverge in roughly 34 scripts across 18 families.** The default
+  template is chosen by `hydra_runner(config_name=...)`, not by the script
+  filename. Most detection families map `inference.py` to `infer.yaml`;
+  `segformer/gen_trt_engine.py` uses `config_name="export"`. Some subtasks
+  (`ml_recog gen_trt_engine`, all of `depth_net` and `visual_changenet`) have
+  no matching default template and only work with an explicit `-e`. Always read
+  the decorator.
+* **`workspace_size` units are inconsistent.** `EngineBuilder(workspace=...)`
+  takes gigabytes, but several specifications express `tensorrt.workspace_size` in megabytes; hence
+  `workspace_size // 1024` conversions inside nine families'
+  `gen_trt_engine.py` (centerpose, deformable_detr, dino, grounding_dino,
+  mask2former, mask_grounding_dino, ml_recog, oneformer, rtdetr). Check the
+  conversion before copying a value.
+* **Multi-GPU is intentionally disabled.** `entrypoint_hydra.launch()` parses
+  `num_gpus`/`gpu_ids` and then clamps to a single GPU. Do not document or rely
+  on multi-GPU behavior.
+* **`model_agnostic` only reaches `cv/` families.** It imports
+  `nvidia_tao_deploy.cv.<model>.scripts`, so `clip` and `video_clip` cannot be
+  driven through it. It reads `model_name` from the raw specification YAML in the parent
+  process and raises `KeyError` if the key is absent. None of the shipped
+  specification templates include it, so you must add it by hand.
+* **UFF paths are effectively dead on current base images.** On TensorRT >= 9
+  the UFF branches in `engine/builder.py` raise `NotImplementedError`, so
+  legacy families are ONNX/ETLT-ONNX only in practice. There is no TensorFlow
+  anywhere in this repo; the TF1- and TF2-era families are TF-*trained* models consumed as
+  exported artifacts.
+* **Dataclass defaults are not the whole story.** The `*_FIELD` factories in
+  `config/utils/types.py` carry both a live `value` (the dataclass default) and
+  separate `default_value` metadata used by specification generation and the FTMS UI,
+  and the two can differ. When documenting a default, check both.
+* **No pytest configuration file exists.** There is no `conftest.py`,
+  `pytest.ini`, or `pyproject.toml`, so the per-family markers used in `tests/`
+  are unregistered and marker selection (`-m`) works only incidentally. Prefer
+  path-based selection: `pytest tests/<family>/`.
+* **`specs_output/experiment.yaml`** at the repository root is a committed generated
+  artifact from an old release. Nothing references it; do not treat it as a
+  template.

--- a/docs/codebase_tour.md
+++ b/docs/codebase_tour.md
@@ -3,8 +3,13 @@
 This is a guided walk through the TAO Deploy repository for developers picking
 up the codebase for the first time. It answers three questions: what each
 directory is for, how the Python package is organized into modules, and where
-the sharp edges are. For the runtime and data-flow view, read
-[Architecture](architecture.md) next.
+the sharp edges are.
+
+For what the product is, how customers run it, and definitions of the terms
+used below (model family, subtask, `tao_deploy`), read the opening sections of
+[Architecture](architecture.md) first; this repository builds the
+`nvcr.io/nvidia/tao/tao-toolkit:<version>-deploy` container, and the console
+commands below are its user-facing surface.
 
 ![TAO Deploy module map](assets/module_map.svg)
 

--- a/docs/deploy_backend_integration.md
+++ b/docs/deploy_backend_integration.md
@@ -105,10 +105,12 @@ writes results under `results_dir`.
 Add focused tests under `tests/MODEL_NAME/`. Match existing local patterns:
 
 ```sh
-python ci/run_static_tests.py
-python ci/run_functional_tests.py --module MODEL_NAME
+pre-commit run --from-ref origin/main --to-ref HEAD
 pytest --color=yes -v tests/MODEL_NAME
 ```
+
+The modern test template is `tests/clip/` / `tests/video_clip/` (config,
+dataloader, engine builder, entrypoint, evaluation, and inferencer tests).
 
 For GPU, TensorRT, model-artifact, or private-dataset tests that cannot be run
 locally, state exactly which checks were skipped and why.

--- a/docs/development_workflows.md
+++ b/docs/development_workflows.md
@@ -1,12 +1,18 @@
 # Development Workflows
 
+This guide gives concrete recipes for common source-code changes.
+
 ## Source Setup
 
+Prepare a fresh checkout with:
+
 ```sh
+git submodule update --init
 source scripts/envsetup.sh
 ```
 
-This sets `NV_TAO_DEPLOY_TOP` and defines the `tao_deploy` shell function.
+This sets `NV_TAO_DEPLOY_TOP`, defines the `tao_deploy` shell function, and
+installs the repository's pre-commit hooks.
 
 Build and install a wheel locally:
 
@@ -15,7 +21,7 @@ make build
 make install
 ```
 
-Build the L4T wheel path:
+Build the L4T (Jetson) wheel:
 
 ```sh
 make build_l4t
@@ -27,7 +33,7 @@ Clean generated package artifacts:
 make clean
 ```
 
-## Run Inside The Base Container
+## Run Inside the Base Container
 
 Use `--` to split launcher arguments from the command that runs inside the
 container:
@@ -39,7 +45,100 @@ tao_deploy --gpus all -- python3 -m pytest tests/core/test_dual_logging.py
 Useful launcher options are documented in
 [Container power users](container_power_users.md).
 
-## Update The Base Image
+## Trace a Command to Code
+
+Use this when a task mentions a command such as `dino gen_trt_engine`.
+
+```sh
+rg -n "dino=" setup.py
+sed -n '1,80p' nvidia_tao_deploy/cv/dino/entrypoint/dino.py
+sed -n '1,200p' nvidia_tao_deploy/cv/dino/scripts/gen_trt_engine.py
+rg -n "config_name=" nvidia_tao_deploy/cv/dino/scripts/
+```
+
+Then inspect the configuration, specifications, and tests:
+
+```sh
+find nvidia_tao_deploy/config/dino -maxdepth 1 -type f | sort
+find nvidia_tao_deploy/cv/dino/specs -maxdepth 1 -type f | sort
+find tests -path '*dino*' -type f | sort
+```
+
+Not every family has a test directory (there is no `tests/dino/`, for
+example). An empty result does not mean you searched wrong.
+
+Remember that some families borrow runtime classes from a sibling — if there is
+no `engine_builder.py` or `inferencer.py` in the package, search for the import
+in the scripts.
+
+## Add a Configuration Field
+
+For a Hydra-style family:
+
+1. Add the dataclass field under `nvidia_tao_deploy/config/<model>/`, using the
+   factories from `nvidia_tao_deploy/config/utils/types.py` (`STR_FIELD`,
+   `INT_FIELD`, ...), including a `description`.
+2. Mirror the field in the relevant specification template under
+   `nvidia_tao_deploy/cv/<model>/specs/` if the default must be visible to users.
+3. Read the field from `cfg` in the consuming script or builder.
+4. If the field mirrors a training-side configuration, confirm the tao-pytorch schema
+   uses the same name and semantics.
+5. Add or update a configuration test (refer to
+   `tests/core/test_common_config.py` and `tests/clip/test_config.py` for
+   patterns).
+
+```sh
+rg -n "class .*Config|DATACLASS_FIELD|STR_FIELD|INT_FIELD" nvidia_tao_deploy/config/<model>
+rg -n "<field_name>" nvidia_tao_deploy/cv/<model> tests
+```
+
+## Update a Model Deploy Flow
+
+For a Hydra-style model:
+
+1. Update the dataclasses in `nvidia_tao_deploy/config/<model>/`.
+2. Update the matching templates in `nvidia_tao_deploy/cv/<model>/specs/` or
+   `nvidia_tao_deploy/multimodal/<model>/specs/`.
+3. Update `scripts/gen_trt_engine.py`, `scripts/inference.py`, or
+   `scripts/evaluate.py`.
+4. Update any model-specific builder, inferencer, dataloader, metric, or
+   post-processing code.
+5. Add or update focused tests under `tests/<model>/`.
+
+For a proto-style model, follow the existing `build_command_line_parser()` and
+proto loader pattern in that model package. Regenerate `*_pb2.py` files with
+`internal/generate_pb2.sh <model>` after editing `.proto` files.
+
+## Add a New Command
+
+1. Add the model package under `nvidia_tao_deploy/cv/` or
+   `nvidia_tao_deploy/multimodal/`.
+2. Add an `entrypoint/` wrapper and `scripts/` package.
+3. Add a `console_scripts` entry in `setup.py`.
+4. Add config dataclasses under `nvidia_tao_deploy/config/` so the command
+   supports schema validation and default specification generation.
+5. Regenerate supported-command docs.
+6. Add tests under `tests/<model>/`. The `tests/clip/` and `tests/video_clip/`
+   suites are the most complete templates (configuration, dataloader, engine
+   builder, entry point, evaluation, and inferencer).
+
+Refer to [Deploy backend integration](deploy_backend_integration.md) for the
+source-backed checklist.
+
+## Update Generated Command Documentation
+
+When `setup.py` console scripts or model `scripts/` packages change:
+
+```sh
+python tools/update_docs_supported_commands.py
+python tools/update_docs_supported_commands.py --check
+```
+
+The generated file is `docs/supported_commands.md`. A pre-commit hook
+regenerates it on commit and fails the commit if it changed, so drift never
+lands.
+
+## Update the Base Image
 
 The base image source is under `docker/`.
 
@@ -55,27 +154,17 @@ Push and record the new digest only after validation:
 bash docker/build.sh --build --x86 --push
 ```
 
-Update the matching platform digest in `docker/manifest.json`.
+Then update the new digest in both places that pin it: the matching platform
+entry in `docker/manifest.json` (read by the `tao_deploy` launcher) and the
+default `X86_DIGEST`/`ARM64_DIGEST` build args at the top of
+`release/docker/Dockerfile.release`. Find any stragglers with
+`grep -rl <old-digest> .`. The Jetson stack (`docker/Dockerfile.l4t`) is
+tracked separately.
 
-**Update every digest reference, not just `docker/manifest.json`.** The base-image
-digest is hardcoded in several files. A base-image rebuild must update all of them for
-the target architecture (`x86` and/or `arm`), or Jenkins and the release build will keep
-pulling the stale image:
+## Build a Release Image
 
-| Location | What it drives |
-| :--- | :--- |
-| `docker/manifest.json` | `tao_deploy` launcher + `ci/utils.py` (static/functional tests); per-arch `x86`/`arm` digests |
-| `Jenkinsfile.dev`, `Jenkinsfile.develop`, `Jenkinsfile.nightly` | the `base-image` container the Jenkins jobs run in |
-| `Jenkinsfile.release` | `BUILD_X86` / `BUILD_ARM` release base images |
-| `release/docker/Dockerfile.release` | `FROM` base digests for the release image |
-
-Find them all with `grep -rl <old-digest> .` and replace per architecture (the `x86`
-and `arm` digests are distinct strings, so a per-digest `sed` is safe). The Jetson
-(`Dockerfile.l4t`) base stack is tracked separately.
-
-## Build A Release Image
-
-The release image installs a wheel built from this repository.
+The release image installs a wheel built from this repository plus the
+tao-core wheel.
 
 ```sh
 source scripts/envsetup.sh
@@ -85,44 +174,3 @@ cd release/docker
 
 Release image tags are assembled in `release/docker/deploy.sh`; package version
 metadata comes from `release/python/version.py`.
-
-## Update A Model Deploy Flow
-
-For a Hydra-style model:
-
-1. Update the dataclasses in `nvidia_tao_deploy/config/MODEL_NAME/`.
-2. Update the matching templates in `nvidia_tao_deploy/cv/MODEL_NAME/specs/` or
-   `nvidia_tao_deploy/multimodal/MODEL_NAME/specs/`.
-3. Update `scripts/gen_trt_engine.py`, `scripts/inference.py`, or
-   `scripts/evaluate.py`.
-4. Update any model-specific builder, inferencer, dataloader, metric, or
-   post-processing code.
-5. Add or update focused tests under `tests/MODEL_NAME/`.
-
-For a proto-style model, follow the existing `build_command_line_parser()` and
-proto loader pattern in that model package.
-
-## Update Generated Command Docs
-
-When `setup.py` console scripts or model `scripts/` packages change:
-
-```sh
-python tools/update_docs_supported_commands.py
-python tools/update_docs_supported_commands.py --check
-```
-
-The generated file is `docs/supported_commands.md`.
-
-## Add A New Command
-
-1. Add the model package under `nvidia_tao_deploy/cv/` or
-   `nvidia_tao_deploy/multimodal/`.
-2. Add an `entrypoint/` wrapper and `scripts/` package.
-3. Add a `console_scripts` entry in `setup.py`.
-4. Add config dataclasses under `nvidia_tao_deploy/config/` when the command
-   supports default spec generation.
-5. Regenerate supported-command docs.
-6. Add tests under `tests/MODEL_NAME/`.
-
-See [Deploy backend integration](deploy_backend_integration.md) for the
-source-backed checklist.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,19 +2,20 @@
 
 This directory documents the TAO Deploy repository from source. It is written for
 contributors, maintainers, coding agents, and power users who need to trace a
-command from CLI entrypoint to TensorRT runtime behavior.
+command from its CLI entry point to TensorRT runtime behavior.
 
 ## Start Here
 
 | Goal | Guide |
 | :--- | :--- |
+| Learn the repository structure and module layout | [Codebase tour](codebase_tour.md) |
 | Build a mental model before editing | [Agent onboarding](agent_onboarding.md) |
 | Trace command, config, and runtime flow | [Architecture](architecture.md) |
 | Make common source or container changes | [Development workflows](development_workflows.md) |
 | Choose and run validation | [Testing and debugging](testing_and_debugging.md) |
 | Run or debug the prebuilt development container | [Container power users](container_power_users.md) |
 | Add or update a model deploy backend | [Deploy backend integration](deploy_backend_integration.md) |
-| See installed model commands | [Supported commands](supported_commands.md) |
+| Look up installed model commands | [Supported commands](supported_commands.md) |
 
 ## Repository Map
 
@@ -30,7 +31,20 @@ command from CLI entrypoint to TensorRT runtime behavior.
 | Structured config dataclasses | `nvidia_tao_deploy/config/` |
 | Shared TensorRT runtime code | `nvidia_tao_deploy/engine/` and `nvidia_tao_deploy/inferencer/` |
 | Shared datasets, metrics, and utilities | `nvidia_tao_deploy/dataloader/`, `nvidia_tao_deploy/metrics/`, and `nvidia_tao_deploy/utils/` |
-| Static and functional test launchers | `ci/run_static_tests.py` and `ci/run_functional_tests.py` |
+| Static checks and CI | `.pre-commit-config.yaml` and `.github/workflows/` |
+
+## Diagrams
+
+Architecture and workflow diagrams are checked in as SVG files under
+`docs/assets/` and embedded with normal Markdown image links. The SVG files are
+the canonical editable sources.
+
+| Diagram | Source |
+| :--- | :--- |
+| Command runtime flow | [assets/source_runtime_flow.svg](assets/source_runtime_flow.svg) |
+| Configuration flow | [assets/config_flow.svg](assets/config_flow.svg) |
+| Package module map | [assets/module_map.svg](assets/module_map.svg) |
+| Container launch flow | [assets/container_flow.svg](assets/container_flow.svg) |
 
 ## Documentation Maintenance
 
@@ -47,5 +61,12 @@ Check for drift with:
 python tools/update_docs_supported_commands.py --check
 ```
 
-The pre-commit hook and GitLab static-test job run the same check so command
-documentation stays aligned with source.
+The pre-commit hook regenerates the file on commit, and the GitHub Actions
+`static-tests` workflow runs the same hooks, so command documentation stays
+aligned with source. Install the hooks
+once per clone:
+
+```sh
+pip install pre-commit
+pre-commit install
+```

--- a/docs/testing_and_debugging.md
+++ b/docs/testing_and_debugging.md
@@ -28,6 +28,30 @@ scanning (`secret-scan.yml`), and PR title format (`pr-title.yml`).
 Functional (GPU) tests run through the externally triggered
 `blossom-ci.yml` workflow, not on every push.
 
+## Test Environment Setup
+
+The base development image has pytest and the runtime dependencies
+(`docker/requirements.txt`, `requirements-dev.txt`), but **not** the TAO
+packages themselves. Set up once per container:
+
+```sh
+# On the host
+git submodule update --init          # tao-core/ is empty otherwise
+source scripts/envsetup.sh
+tao_deploy --gpus all -- bash
+
+# Inside the container (repository is mounted at /workspace/tao-deploy)
+pip install /workspace/tao-deploy/tao-core/.   # provides nvidia_tao_core
+cd /workspace/tao-deploy && python setup.py develop   # console commands + package
+pytest --color=yes -v tests/core/test_dual_logging.py  # smoke check
+```
+
+`nvidia_tao_core` is not in the requirements files, and its import in
+`status_logging.py` is unguarded, so nearly every test and command fails until
+the submodule is installed. Engine and inferencer tests additionally need a
+GPU, TensorRT, and model artifacts; several suites expect datasets mounted
+from private paths.
+
 ## Test Map
 
 | Area | Examples |

--- a/docs/testing_and_debugging.md
+++ b/docs/testing_and_debugging.md
@@ -1,74 +1,114 @@
-# Testing And Debugging
+# Testing and Debugging
+
+Use this guide to choose targeted checks and diagnose common TAO Deploy
+development failures.
 
 ## Static Checks
 
-GitLab runs `static_tests` from `.gitlab-ci.yml`. The job first checks generated
-command documentation and then runs the static test launcher:
+CI runs static checks on pull requests through GitHub Actions
+(`.github/workflows/static-tests.yml`), which executes the repository's pre-commit
+hooks against the changed files:
+
+* SPDX license headers (`.github/hooks/check_license_header.py`)
+* `pylint` (`.pylintrc`), `pydocstyle`, and `flake8`, scoped to
+  `nvidia_tao_deploy/`
+* The generated-documentation hook (`tools/update_docs_supported_commands.py`),
+  which regenerates `docs/supported_commands.md` and fails on drift
+
+Reproduce locally:
 
 ```sh
-python tools/update_docs_supported_commands.py --check
-python ci/run_static_tests.py
+pip install pre-commit
+pre-commit install
+pre-commit run --from-ref origin/main --to-ref HEAD
 ```
 
-`ci/run_static_tests.py` runs `pylint`, `pydocstyle`, and `flake8` against the
-configured source modules. Outside CI it launches those checks inside the base
-container from `docker/manifest.json`.
-
-## Functional Tests
-
-Run all functional tests:
-
-```sh
-python ci/run_functional_tests.py
-```
-
-Run a model subset:
-
-```sh
-python ci/run_functional_tests.py --module clip
-```
-
-Run a focused pytest directly when the environment already has dependencies:
-
-```sh
-pytest --color=yes -v tests/core/test_dual_logging.py
-pytest --color=yes -v tests/clip/test_evaluation.py
-```
+Separate workflows enforce DCO sign-off on every commit (`dco.yml`), secret
+scanning (`secret-scan.yml`), and PR title format (`pr-title.yml`).
+Functional (GPU) tests run through the externally triggered
+`blossom-ci.yml` workflow, not on every push.
 
 ## Test Map
 
 | Area | Examples |
 | :--- | :--- |
-| Core utilities | `tests/core/test_decrypt.py`, `tests/core/test_dual_logging.py` |
-| TensorRT engine flows | `tests/*/test_engine.py`, `tests/*/test_engine_builder.py` |
-| Dataloaders | `tests/*/test_dataloader.py`, `tests/depth_net/test_loader.py` |
-| Inference helpers | `tests/clip/test_inferencer.py`, model-specific inferencer tests |
+| Core utilities | `tests/core/test_decrypt.py`, `tests/core/test_dual_logging.py`, `tests/core/test_common_config.py` |
+| Schema drift vs tao-pytorch | `tests/core/test_backbone_schema_drift.py` |
+| TensorRT engine flows | `tests/<model>/test_engine.py`, `tests/<model>/test_engine_builder.py` |
+| Dataloaders | `tests/<model>/test_dataloader.py` |
+| Inference helpers | `tests/clip/test_inferencer.py` and other model inferencer tests |
 | Metrics and evaluation | `tests/clip/test_evaluation.py`, model `evaluate` tests |
+| Full modern template | `tests/clip/`, `tests/video_clip/` (config, dataloader, engine builder, entrypoint, evaluation, inferencer) |
 
-Many engine tests require GPUs, TensorRT, model artifacts, and data mounted from
-private paths such as `/home/scratch.metropolis2`. Prefer targeted tests for
-small source changes and state clearly when those heavier checks were not run.
+The repository has no `conftest.py` or pytest configuration file, so the
+per-family markers used in test files are unregistered. Prefer path-based
+selection:
+
+```sh
+pytest --color=yes -v tests/core/
+pytest --color=yes -v tests/<model>/
+```
+
+Many engine tests require GPUs, TensorRT, model artifacts, and datasets mounted
+from private paths. Prefer targeted tests for small source changes and state
+clearly when you did not run the heavier checks.
+
+## Documentation Checks
+
+For documentation-only changes:
+
+```sh
+python tools/update_docs_supported_commands.py --check
+python -m py_compile tools/update_docs_supported_commands.py
+git diff --check -- README.md docs/*.md docs/assets/*.svg tools/*.py .pre-commit-config.yaml
+```
 
 ## Common Failures
 
 | Symptom | Likely source | Check |
 | :--- | :--- | :--- |
 | `git status` fails on LFS clean filter | Read-only `.git/lfs/tmp` | Use `git -c filter.lfs.process= -c filter.lfs.required=false status --short --branch`. |
+| Import errors for `nvidia_tao_core` | Uninitialized `tao-core/` submodule | `git submodule update --init`; in containers, `envsetup.sh` adds `/workspace/tao-deploy/tao-core` to `PYTHONPATH`. This import is unguarded in `status_logging.py`, so almost every command fails without it. |
 | Base image pull fails | NGC login or network access | `docker login nvcr.io` and inspect `docker/manifest.json`. |
-| Static tests run differently locally | `ci/run_static_tests.py` launches Docker outside CI | Check `CI_PROJECT_DIR` and `NV_TAO_DEPLOY_TOP`. |
-| Import errors for `nvidia_tao_core` | Local container does not have the core wheel | `ci/run_functional_tests.py` adds `/workspace/tao-deploy/tao-core` to `PYTHONPATH`. |
-| TensorRT or CUDA errors | Host/container mismatch or missing GPU | Check `--gpus`, driver, CUDA, TensorRT, and `nvidia-container-toolkit`. |
-| Generated docs check fails | `setup.py` or `scripts/` changed | Run `python tools/update_docs_supported_commands.py`. |
+| TensorRT or CUDA errors | Host and container mismatch or missing GPU | Check `--gpus`, driver, CUDA, TensorRT, and `nvidia-container-toolkit`. |
+| Generated documentation check fails | `setup.py` or a `scripts/` package changed | Run `python tools/update_docs_supported_commands.py`. |
+| `default_specs` or a subtask cannot find its template | Specification template name diverges from the subtask name | Read the script's `hydra_runner(config_name=...)`; refer to the divergence table in [Architecture](architecture.md). |
+| Breakpoints in a `scripts/*.py` never trigger | The entrypoint launches scripts as a fresh subprocess | Run the script module directly with `--config-path`/`--config-name`. |
+| UFF model paths raise `NotImplementedError` | TensorRT >= 9 removed UFF support | Legacy families are ONNX/ETLT-ONNX only on current base images. |
+| Engine build OOMs or workspace looks wrong | `workspace_size` unit mismatch (megabytes in some specifications, gigabytes in `EngineBuilder`) | Check for `// 1024` conversions in the family's `gen_trt_engine.py`. |
 
-## Documentation Checks
+## Debugging Patterns
 
-For docs-only changes:
+Trace command launch:
 
 ```sh
-python tools/update_docs_supported_commands.py --check
-python -m py_compile tools/update_docs_supported_commands.py
-git diff --check -- README.md docs/*.md docs/assets/*.svg tools/*.py .pre-commit-config.yaml .gitlab-ci.yml
+rg -n "<command>=" setup.py
+sed -n '1,260p' nvidia_tao_deploy/cv/common/entrypoint/entrypoint_hydra.py
 ```
 
-GPU, Docker, TensorRT, dataset, and private-checkpoint tests are normally out of
-scope for documentation-only updates unless the docs changed runnable behavior.
+Trace config:
+
+```sh
+find nvidia_tao_deploy/config/<model> -maxdepth 1 -type f | sort
+find nvidia_tao_deploy/cv/<model>/specs -maxdepth 2 -type f | sort
+rg -n "config_name=" nvidia_tao_deploy/cv/<model>/scripts/
+```
+
+Trace engine building:
+
+```sh
+rg -n "EngineBuilder|create_network|create_engine" nvidia_tao_deploy/cv/<model> nvidia_tao_deploy/engine
+```
+
+Trace inference:
+
+```sh
+rg -n "TRTInferencer|allocate_buffers|do_inference|infer\(" nvidia_tao_deploy/cv/<model> nvidia_tao_deploy/inferencer
+```
+
+Run a script in-process (debuggable, bypasses the subprocess launch):
+
+```sh
+python nvidia_tao_deploy/cv/<model>/scripts/<subtask>.py \
+  --config-path /abs/path/to/spec/dir --config-name <spec_name>
+```


### PR DESCRIPTION
Brings the tao-deploy developer docs to parity with tao-pytorch's docs tree and addresses feedback that the repo structure, modules, and architecture are hard for new developers to pick up.

**What changed**
- **New `docs/codebase_tour.md`** — annotated repo tree, package module map, hydra-vs-proto family inventory, anatomy of the `dino` family, and a consolidated sharp-edges list (config_name divergences, `workspace_size` units, subprocess launch, `model_agnostic` limits, UFF status on TRT >= 9, submodule requirement).
- **Expanded `docs/architecture.md`** — the three entrypoint styles, config field factories and metadata, a config_name divergence audit table, the layered TensorRT runtime, the tao-core boundary, and the cross-repo contract with tao-pytorch.
- **Two new diagrams** (`config_flow.svg`, `module_map.svg`) in the same style as tao-pytorch's.
- **GitHub-era CI corrections** across agent_onboarding / development_workflows / testing_and_debugging / index: removed stale `.gitlab-ci.yml` / `ci/run_static_tests.py` / Jenkinsfile references; documented the pre-commit + GitHub Actions checks that actually run; corrected base-image digest bump locations (manifest + release Dockerfile ARG defaults).

**Verification**
- Every path, class name, and `config_name` value cross-checked against source at origin/main.
- `python tools/update_docs_supported_commands.py --check` passes; `git diff --check` clean; SVGs are valid XML; all relative doc links resolve.
- Docs-only change; no runtime code touched.

JIRA: [TAO-2523](https://jirasw.nvidia.com/browse/TAO-2523)